### PR TITLE
realease yaml added to push to pypi the code and updated toml file 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,31 @@
+name: Upload Python Package to PyPI when a Release is Created
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  pypi-publish:
+    name: Publish release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gridfm-datakit
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -e .[dev,test]
+      - name: Build package
+        run: |
+          python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,11 @@ build-backend = "setuptools.build_meta"
 include = ["gridfm_datakit*"]
 
 [project]
-name = "gridfm_datakit"
+name = "gridfm-datakit"
 description = "Data Generation Kit"
 readme = "README.md"
 license = "Apache-2.0"
-version = "0.1.0"
+version = "0.0.1"
 requires-python = ">=3.9,<3.13"
 dependencies = [
     "ipykernel",
@@ -39,6 +39,12 @@ maintainers = [
   {name = "Alban Puech", email = "Alban.Puech1@ibm.com"},
 ]
 
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Programming Language :: Python :: 3.9",
+  "Topic :: Scientific/Engineering"
+]
+
 [project.scripts]
 gridfm_datakit = "gridfm_datakit.cli:main"
 
@@ -48,7 +54,8 @@ dev = [
   "mkdocs-material",
   "mkdocstrings[python]",
   "pre-commit",
-  "bandit"
+  "bandit",
+  "build"
 ]
 
 test = [


### PR DESCRIPTION
In this PR, I'm adding to the `pyproject.toml` file the following:
- New version 0.0.1
- project name with - not _
- Classifier tags for Pypi :
`
  "Development Status :: 2 - Pre-Alpha",
  "Programming Language :: Python :: 3.9",
  "Topic :: Scientific/Engineering"
`

- `Build` as a dependency on dev to create the `dist` folder.

Tested locally on new env python 3.10:  
```
Copying gridfm_datakit.egg-info to build/bdist.macosx-11.0-arm64/wheel/./gridfm_datakit-0.0.1-py3.10.egg-info
running install_scripts
creating build/bdist.macosx-11.0-arm64/wheel/gridfm_datakit-0.0.1.dist-info/WHEEL
creating '/Users/celiacintas/Code/gridfm/gridfm-datakit/dist/.tmp-lpdmhuuf/gridfm_datakit-0.0.1-py3-none-any.whl' and adding 'build/bdist.macosx-11.0-arm64/wheel' to it
adding 'gridfm_datakit/__init__.py'
adding 'gridfm_datakit/cli.py'
adding 'gridfm_datakit/generate.py'
adding 'gridfm_datakit/interactive.py'
adding 'gridfm_datakit/network.py'
adding 'gridfm_datakit/save.py'
adding 'gridfm_datakit/grids/__init__.py'
adding 'gridfm_datakit/load_profiles/__init__.py'
adding 'gridfm_datakit/perturbations/__init__.py'
adding 'gridfm_datakit/perturbations/load_perturbation.py'
adding 'gridfm_datakit/perturbations/topology_perturbation.py'
adding 'gridfm_datakit/process/__init__.py'
adding 'gridfm_datakit/process/process_network.py'
adding 'gridfm_datakit/process/solvers.py'
adding 'gridfm_datakit/utils/__init__.py'
adding 'gridfm_datakit/utils/config.py'
adding 'gridfm_datakit/utils/param_handler.py'
adding 'gridfm_datakit/utils/stats.py'
adding 'gridfm_datakit/utils/utils.py'
adding 'gridfm_datakit-0.0.1.dist-info/licenses/LICENSE'
adding 'gridfm_datakit-0.0.1.dist-info/METADATA'
adding 'gridfm_datakit-0.0.1.dist-info/WHEEL'
adding 'gridfm_datakit-0.0.1.dist-info/entry_points.txt'
adding 'gridfm_datakit-0.0.1.dist-info/top_level.txt'
adding 'gridfm_datakit-0.0.1.dist-info/RECORD'
removing build/bdist.macosx-11.0-arm64/wheel
Successfully built gridfm_datakit-0.0.1.tar.gz and gridfm_datakit-0.0.1-py3-none-any.whl
```

And lastly, a new `release.yaml` to use as Trusted Publisher for Pypi, I will need to add it on my pypi user after merging to main, and a release version is created. 