### PR TITLE
Centralize solver output control; suppress Ipopt/PowerModels flood by default

### DIFF
--- a/gridfm_datakit/network.py
+++ b/gridfm_datakit/network.py
@@ -85,9 +85,11 @@ def correct_network(network_path: str, force: bool = False) -> str:
         project = STATE["project"]
         jl_exe = executable()
 
-        # Julia script as a list of lines
+        # Julia script as a list of lines. silence() suppresses PowerModels'
+        # Info/Warn chatter from parse_file/export_matpower.
         julia_code = [
             "using PowerModels",
+            "PowerModels.silence()",
             f'data = PowerModels.parse_file("{network_path}")',
             f'PowerModels.export_matpower("{tmp_path}", data)',
         ]

--- a/gridfm_datakit/perturbations/load_perturbation.py
+++ b/gridfm_datakit/perturbations/load_perturbation.py
@@ -31,7 +31,7 @@ def _find_largest_scaling_factor_worker(
     import tempfile
     import os
 
-    jl = init_julia(max_iter=max_iter, solver_log_dir=None, print_level=5)
+    jl = init_julia(max_iter=max_iter, solver_log_dir=None)
 
     while (u <= max_scaling) and converged:
         # Update load values in the Network using properties

--- a/gridfm_datakit/process/process_network.py
+++ b/gridfm_datakit/process/process_network.py
@@ -10,7 +10,6 @@ import copy
 import os
 import time
 import traceback
-from contextlib import nullcontext
 from importlib import resources
 from queue import Queue
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -63,7 +62,11 @@ from gridfm_datakit.utils.idx_bus import (
 from gridfm_datakit.utils.idx_cost import COST, NCOST
 from gridfm_datakit.utils.idx_gen import GEN_BUS, PMAX, PMIN, QMAX, QMIN
 from gridfm_datakit.utils.random_seed import custom_seed
-from gridfm_datakit.process.solver_output import SolverOutputConfig, redirect_c_stdio
+from gridfm_datakit.process.solver_output import (
+    SolverOutputConfig,
+    build_router,
+    set_active_router,
+)
 
 
 def init_julia(
@@ -115,11 +118,11 @@ def init_julia(
 
     from juliacall import Main as jl
 
-    # Per-solver log paths; "" means Julia aliases the solver without redirection.
-    opf_solver_log_file = output.log_file("opf") or ""
-    pf_solver_log_file = output.log_file("pf") or ""
-    dcpf_solver_log_file = output.log_file("dcpf") or ""
-    dcopf_solver_log_file = output.log_file("dcopf") or ""
+    # Route every sub-system's output through one process-wide policy. The
+    # solver entrypoints below are plain aliases to their cores; capture happens
+    # in Python around each call (see process.solvers), not baked into Julia.
+    router = build_router(output)
+    set_active_router(router)
 
     print_level = ipopt_print_level
 
@@ -193,26 +196,9 @@ def init_julia(
         """.format(print_level, max_iter),
         )
 
-        # run_opf: either alias to core (no logging) or wrap with redirection (logging)
-        if opf_solver_log_file == "":
-            jl.seval("""
-            const run_opf = _run_opf_core
-            """)
-        else:
-            jl.seval(
-                """
-            function run_opf(case_file)
-                open("{}", "a") do io
-
-                    redirect_stdout(io) do
-                        redirect_stderr(io) do
-                            return _run_opf_core(case_file)
-                        end
-                    end
-                end
-            end
-            """.format(opf_solver_log_file),
-            )
+        # Output routing is handled in Python (fd-level capture around the call),
+        # so the entrypoint is a plain alias to its core.
+        jl.seval("const run_opf = _run_opf_core")
 
         # ----- DC-OPF core -----
         jl.seval(
@@ -236,26 +222,7 @@ def init_julia(
         """.format(print_level, dc_iter),
         )
 
-        # run_dcopf: either alias to core (no logging) or wrap with redirection (logging)
-        if dcopf_solver_log_file == "":
-            jl.seval("""
-            const run_dcopf = _run_dcopf_core
-            """)
-        else:
-            jl.seval(
-                """
-            function run_dcopf(case_file)
-                open("{}", "a") do io
-
-                    redirect_stdout(io) do
-                        redirect_stderr(io) do
-                            return _run_dcopf_core(case_file)
-                        end
-                    end
-                end
-            end
-            """.format(dcopf_solver_log_file),
-            )
+        jl.seval("const run_dcopf = _run_dcopf_core")
 
         # ----- Fast PF (direct computation) -----
         jl.seval("""
@@ -324,26 +291,7 @@ def init_julia(
         """.format(print_level, max_iter),
         )
 
-        # run_pf: either alias to core (no logging) or wrap with redirection (logging)
-        if pf_solver_log_file == "":
-            jl.seval("""
-            const run_pf = _run_pf_core
-            """)
-        else:
-            jl.seval(
-                """
-            function run_pf(case_file)
-                open("{}", "a") do io
-
-                    redirect_stdout(io) do
-                        redirect_stderr(io) do
-                            return _run_pf_core(case_file)
-                        end
-                    end
-                end
-            end
-            """.format(pf_solver_log_file),
-            )
+        jl.seval("const run_pf = _run_pf_core")
 
         # ----- DC-PF core -----
         jl.seval(
@@ -374,66 +322,36 @@ def init_julia(
         """.format(print_level, dc_iter),
         )
 
-        # run_dcpf: either alias to core (no logging) or wrap with redirection (logging)
-        if dcpf_solver_log_file == "":
-            jl.seval("""
-            const run_dcpf = _run_dcpf_core
-            """)
-        else:
-            jl.seval(
-                """
-            function run_dcpf(case_file)
-                open("{}", "a") do io
-
-                    redirect_stdout(io) do
-                        redirect_stderr(io) do
-                            return _run_dcpf_core(case_file)
-                        end
-                    end
-                end
-            end
-            """.format(dcpf_solver_log_file),
-            )
+        jl.seval("const run_dcpf = _run_dcpf_core")
 
         # Warm start all functions on a dummy case. Ipopt prints its one-time
-        # license banner here at the C level; when nothing should reach the
-        # console and we're not logging to files, discard it.
+        # license banner here at the C level; each warm-up runs inside its
+        # channel's capture, so the banner lands wherever that channel points
+        # (a file, or /dev/null when silent) instead of leaking to the console.
         dummy_case_file = str(
             resources.files("gridfm_datakit.process").joinpath("dummy.m"),
         )
-        discard_banner = not output.to_console and output.log_dir is None
-        with redirect_c_stdio(None) if discard_banner else nullcontext():
-            if output.to_console:
-                print("\n ======= warm starting Julia interface =======\n", flush=True)
-            if opf_solver_log_file:
-                with open(opf_solver_log_file, "a") as f:
-                    f.write(" ======= warm starting opf function =======\n")
-            jl.run_opf(dummy_case_file)
+        if output.to_console:
+            print("\n ======= warm starting Julia interface =======\n", flush=True)
 
-            if dcopf_solver_log_file:
-                with open(dcopf_solver_log_file, "a") as f:
-                    f.write(" ======= warm starting dcopf function =======\n")
-            jl.run_dcopf(dummy_case_file)
+        # (channel name, Julia entrypoint). Fast paths share their channel with
+        # the optimizer-based one; they warm up under the same capture.
+        warmups = [
+            ("opf", jl.run_opf),
+            ("dcopf", jl.run_dcopf),
+            ("pf", jl.run_pf_fast),
+            ("pf", jl.run_pf),
+            ("dcpf", jl.run_dcpf),
+            ("dcpf", jl.run_dcpf_fast),
+        ]
+        for name, fn in warmups:
+            channel = router.channel(name)
+            channel.write_header(f" ======= warm starting {name} function =======")
+            with channel.capture():
+                fn(dummy_case_file)
 
-            jl.run_pf_fast(dummy_case_file)  # no log file
-
-            if pf_solver_log_file:
-                with open(pf_solver_log_file, "a") as f:
-                    f.write(" ======= warm starting pf function =======\n")
-            jl.run_pf(dummy_case_file)
-
-            if dcpf_solver_log_file:
-                with open(dcpf_solver_log_file, "a") as f:
-                    f.write(" ======= warm starting dcpf function =======\n")
-            jl.run_dcpf(dummy_case_file)
-
-            jl.run_dcpf_fast(dummy_case_file)  # no log file
-
-            if output.to_console:
-                print(
-                    "\n ======= warm starting completed =======\n",
-                    flush=True,
-                )
+        if output.to_console:
+            print("\n ======= warm starting completed =======\n", flush=True)
 
     except Exception as e:
         raise RuntimeError("Error initializing Julia: {}".format(e))

--- a/gridfm_datakit/process/process_network.py
+++ b/gridfm_datakit/process/process_network.py
@@ -126,11 +126,13 @@ def init_julia(
     try:
         if julia_project:
             jl_project = julia_project.replace("\\", "/")
+            # io=devnull silences the "Activating project at ..." banner that
+            # Pkg prints once per worker.
             jl.seval(
                 f'''
                 using Pkg
-                Pkg.activate(raw"{jl_project}")
-                Pkg.instantiate()
+                Pkg.activate(raw"{jl_project}"; io=devnull)
+                Pkg.instantiate(; io=devnull)
                 ''',
             )
 

--- a/gridfm_datakit/process/process_network.py
+++ b/gridfm_datakit/process/process_network.py
@@ -7,10 +7,10 @@ for data generation purposes.
 """
 
 import copy
-import multiprocessing
 import os
 import time
 import traceback
+from contextlib import nullcontext
 from importlib import resources
 from queue import Queue
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -63,6 +63,7 @@ from gridfm_datakit.utils.idx_bus import (
 from gridfm_datakit.utils.idx_cost import COST, NCOST
 from gridfm_datakit.utils.idx_gen import GEN_BUS, PMAX, PMIN, QMAX, QMIN
 from gridfm_datakit.utils.random_seed import custom_seed
+from gridfm_datakit.process.solver_output import SolverOutputConfig, redirect_c_stdio
 
 
 def init_julia(
@@ -70,18 +71,23 @@ def init_julia(
     solver_log_dir: str = None,
     dc_max_iter: Optional[int] = None,
     print_level: Optional[int] = None,
+    output: Optional[SolverOutputConfig] = None,
 ) -> Any:
     """Initialize Julia interface with PowerModels.jl.
 
     Sets up Julia environment and defines AC OPF/PF/DCPF entrypoints.
 
+    Solver output is governed by a single :class:`SolverOutputConfig`. Pass
+    ``output`` directly, or rely on the legacy ``solver_log_dir`` /
+    ``print_level`` arguments, which are folded into an equivalent config.
+
     Args:
         max_iter: Maximum number of iterations for AC OPF solver.
-        solver_log_dir: If provided, enable OPF/PF logging to files under this
-            directory using per-process names (opf_<proc>.log, pf_<proc>.log).
-            If None, logging is disabled.
-        dc_max_iter: Maximum number of iterations for DC OPF solver. If None, uses 1000.
-        print_level: Ipopt print level. If None, uses 0 when solver_log_dir is None, else 5.
+        solver_log_dir: Legacy. Enables solver logging to files under this
+            directory when ``output`` is None.
+        dc_max_iter: Maximum number of iterations for DC OPF solver (default 1000).
+        print_level: Legacy. Explicit Ipopt print level override.
+        output: Solver-output config; takes precedence over the legacy args.
 
     Returns:
         Julia interface object for running power flow calculations.
@@ -89,6 +95,13 @@ def init_julia(
     Raises:
         RuntimeError: If Julia initialization fails.
     """
+    if output is None:
+        output = SolverOutputConfig.from_settings(
+            log_dir=solver_log_dir,
+            enable_solver_logs=solver_log_dir is not None,
+        )
+    # An explicit legacy print_level still wins over the verbosity-derived one.
+    ipopt_print_level = output.ipopt_print_level if print_level is None else print_level
     # Ensure spawned workers use the same Julia project so package resolution is consistent.
     julia_project = None
     try:
@@ -102,43 +115,13 @@ def init_julia(
 
     from juliacall import Main as jl
 
-    # Decide log paths and Ipopt print levels
-    proc = multiprocessing.current_process().name
+    # Per-solver log paths; "" means Julia aliases the solver without redirection.
+    opf_solver_log_file = output.log_file("opf") or ""
+    pf_solver_log_file = output.log_file("pf") or ""
+    dcpf_solver_log_file = output.log_file("dcpf") or ""
+    dcopf_solver_log_file = output.log_file("dcopf") or ""
 
-    opf_solver_log_file = (
-        ""
-        if solver_log_dir is None
-        else os.path.join(solver_log_dir, "opf_" + str(proc) + ".log").replace(
-            "\\",
-            "/",
-        )
-    )
-    pf_solver_log_file = (
-        ""
-        if solver_log_dir is None
-        else os.path.join(solver_log_dir, "pf_" + str(proc) + ".log").replace("\\", "/")
-    )
-    dcpf_solver_log_file = (
-        ""
-        if solver_log_dir is None
-        else os.path.join(solver_log_dir, "dcpf_" + str(proc) + ".log").replace(
-            "\\",
-            "/",
-        )
-    )
-    dcopf_solver_log_file = (
-        ""
-        if solver_log_dir is None
-        else os.path.join(solver_log_dir, "dcopf_" + str(proc) + ".log").replace(
-            "\\",
-            "/",
-        )
-    )
-
-    if print_level is None:
-        print_level = 0 if solver_log_dir is None else 5
-    else:
-        print_level = print_level
+    print_level = ipopt_print_level
 
     try:
         if julia_project:
@@ -153,13 +136,18 @@ def init_julia(
 
         # If dc_max_iter not provided, use 1000
         dc_iter = 1000 if dc_max_iter is None else dc_max_iter
+        # Memento.config! sets the root logger; PowerModels.silence() is what
+        # actually quiets PowerModels' own Info/Warn (see SolverOutputConfig).
+        memento_level = output.memento_level
+        silence_pm = "PowerModels.silence()" if output.silence_powermodels else ""
         # Base imports and logging config in Julia
         try:
-            jl.seval("""
+            jl.seval(f"""
             using PowerModels
             using Ipopt
             using Memento
-            Memento.config!("not_set")
+            Memento.config!("{memento_level}")
+            {silence_pm}
             """)
         except Exception as e:
             msg = str(e)
@@ -167,7 +155,7 @@ def init_julia(
             missing_ipopt = "Package Ipopt not found" in msg
             missing_memento = "Package Memento not found" in msg
             if missing_pm or missing_ipopt or missing_memento:
-                jl.seval("""
+                jl.seval(f"""
                 using Pkg
                 Pkg.add("Ipopt")
                 Pkg.add("PowerModels")
@@ -175,7 +163,8 @@ def init_julia(
                 using PowerModels
                 using Ipopt
                 using Memento
-                Memento.config!("not_set")
+                Memento.config!("{memento_level}")
+                {silence_pm}
                 """)
             else:
                 raise
@@ -404,47 +393,45 @@ def init_julia(
             """.format(dcpf_solver_log_file),
             )
 
-        # warm start all functions by running a dummy case
+        # Warm start all functions on a dummy case. Ipopt prints its one-time
+        # license banner here at the C level; when nothing should reach the
+        # console and we're not logging to files, discard it.
         dummy_case_file = str(
             resources.files("gridfm_datakit.process").joinpath("dummy.m"),
         )
-        if print_level > 0 and solver_log_dir is None:
-            print("\n ======= warm starting Julia interface =======\n", flush=True)
-        if opf_solver_log_file:
-            with open(opf_solver_log_file, "a") as f:
-                f.write(" ======= warm starting Julia interface opf function =======\n")
-        jl.run_opf(dummy_case_file)
+        discard_banner = not output.to_console and output.log_dir is None
+        with redirect_c_stdio(None) if discard_banner else nullcontext():
+            if output.to_console:
+                print("\n ======= warm starting Julia interface =======\n", flush=True)
+            if opf_solver_log_file:
+                with open(opf_solver_log_file, "a") as f:
+                    f.write(" ======= warm starting opf function =======\n")
+            jl.run_opf(dummy_case_file)
 
-        if dcopf_solver_log_file:
-            with open(dcopf_solver_log_file, "a") as f:
-                f.write(
-                    " ======= warm starting Julia interface dcopf function =======\n",
+            if dcopf_solver_log_file:
+                with open(dcopf_solver_log_file, "a") as f:
+                    f.write(" ======= warm starting dcopf function =======\n")
+            jl.run_dcopf(dummy_case_file)
+
+            jl.run_pf_fast(dummy_case_file)  # no log file
+
+            if pf_solver_log_file:
+                with open(pf_solver_log_file, "a") as f:
+                    f.write(" ======= warm starting pf function =======\n")
+            jl.run_pf(dummy_case_file)
+
+            if dcpf_solver_log_file:
+                with open(dcpf_solver_log_file, "a") as f:
+                    f.write(" ======= warm starting dcpf function =======\n")
+            jl.run_dcpf(dummy_case_file)
+
+            jl.run_dcpf_fast(dummy_case_file)  # no log file
+
+            if output.to_console:
+                print(
+                    "\n ======= warm starting completed =======\n",
+                    flush=True,
                 )
-        jl.run_dcopf(dummy_case_file)
-
-        # run_pf_fast has no log file
-        jl.run_pf_fast(dummy_case_file)
-
-        if pf_solver_log_file:
-            with open(pf_solver_log_file, "a") as f:
-                f.write(" ======= warm starting Julia interface pf function =======\n")
-        jl.run_pf(dummy_case_file)
-
-        if dcpf_solver_log_file:
-            with open(dcpf_solver_log_file, "a") as f:
-                f.write(
-                    " ======= warm starting Julia interface dcpf function =======\n",
-                )
-        jl.run_dcpf(dummy_case_file)
-
-        # run_dcpf_fast has no log file
-        jl.run_dcpf_fast(dummy_case_file)
-
-        if print_level > 0 and solver_log_dir is None:
-            print(
-                "\n ======= warm starting Julia interface completed =======\n",
-                flush=True,
-            )
 
     except Exception as e:
         raise RuntimeError("Error initializing Julia: {}".format(e))

--- a/gridfm_datakit/process/solver_output.py
+++ b/gridfm_datakit/process/solver_output.py
@@ -1,0 +1,162 @@
+"""Centralized control of Julia/PowerModels/Ipopt solver output.
+
+One :class:`SolverOutputConfig` maps a single verbosity level onto the three
+places solver chatter comes from: Ipopt's ``print_level``, PowerModels'
+``silence()``, and Memento's root logger. :func:`redirect_c_stdio` is the
+companion for the cases the loggers can't reach -- Ipopt and MUMPS write
+straight to file descriptors 1/2, so only an OS-level dup2 captures them.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Iterator, Optional
+
+try:
+    _LIBC: Optional[ctypes.CDLL] = ctypes.CDLL(None)
+except Exception:  # pragma: no cover - platform without a loadable libc
+    _LIBC = None
+
+
+class SolverVerbosity(IntEnum):
+    """Solver verbosity, from quietest to loudest."""
+
+    SILENT = 0
+    ERROR = 1
+    WARNING = 2
+    INFO = 3
+    DEBUG = 4
+
+    @classmethod
+    def parse(cls, value: "SolverVerbosity | str | int") -> "SolverVerbosity":
+        """Coerce a name (case-insensitive), int, or member into a member."""
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, str):
+            try:
+                return cls[value.strip().upper()]
+            except KeyError:
+                names = [m.name.lower() for m in cls]
+                raise ValueError(
+                    f"unknown verbosity {value!r}; expected one of {names}",
+                )
+        return cls(int(value))
+
+
+# Ipopt print levels run 0..12; 5 already prints the full iteration table.
+_IPOPT_PRINT_LEVEL = {
+    SolverVerbosity.SILENT: 0,
+    SolverVerbosity.ERROR: 0,
+    SolverVerbosity.WARNING: 0,
+    SolverVerbosity.INFO: 3,
+    SolverVerbosity.DEBUG: 5,
+}
+
+_MEMENTO_LEVEL = {
+    SolverVerbosity.SILENT: "not_set",
+    SolverVerbosity.ERROR: "error",
+    SolverVerbosity.WARNING: "warn",
+    SolverVerbosity.INFO: "info",
+    SolverVerbosity.DEBUG: "debug",
+}
+
+
+@dataclass(frozen=True)
+class SolverOutputConfig:
+    """How much the solvers should print, and where it goes.
+
+    With ``log_dir`` set, output is captured to per-process files; otherwise it
+    reaches the console (or is dropped when SILENT).
+    """
+
+    verbosity: SolverVerbosity = SolverVerbosity.SILENT
+    log_dir: Optional[str] = None
+
+    @classmethod
+    def from_settings(
+        cls,
+        verbosity: "SolverVerbosity | str | int | None" = None,
+        log_dir: Optional[str] = None,
+        enable_solver_logs: bool = False,
+    ) -> "SolverOutputConfig":
+        """Build a config from user settings.
+
+        When ``verbosity`` is omitted it defaults to DEBUG if logs are enabled
+        (matching the old "write everything to files" behaviour) else SILENT.
+        """
+        if verbosity is None:
+            verbosity = (
+                SolverVerbosity.DEBUG if enable_solver_logs else SolverVerbosity.SILENT
+            )
+        return cls(
+            SolverVerbosity.parse(verbosity),
+            log_dir if enable_solver_logs else None,
+        )
+
+    @property
+    def ipopt_print_level(self) -> int:
+        return _IPOPT_PRINT_LEVEL[self.verbosity]
+
+    @property
+    def memento_level(self) -> str:
+        return _MEMENTO_LEVEL[self.verbosity]
+
+    @property
+    def silence_powermodels(self) -> bool:
+        # PowerModels logs through its own Memento logger, which ignores the
+        # root level, so silence() is the only thing that quiets its Info/Warn.
+        return self.verbosity < SolverVerbosity.INFO
+
+    @property
+    def to_console(self) -> bool:
+        return self.log_dir is None and self.verbosity > SolverVerbosity.SILENT
+
+    def log_file(self, name: str) -> Optional[str]:
+        """Per-process log path for solver ``name`` (e.g. "opf"), or None."""
+        if self.log_dir is None:
+            return None
+        import multiprocessing
+
+        proc = multiprocessing.current_process().name
+        return os.path.join(self.log_dir, f"{name}_{proc}.log").replace("\\", "/")
+
+
+@contextmanager
+def redirect_c_stdio(target: Optional[str]) -> Iterator[None]:
+    """Redirect fd 1 and 2 to ``target`` (a file) or /dev/null (when None).
+
+    Works at the file-descriptor level, so unlike ``redirect_stdout`` it also
+    captures C/Fortran output from Ipopt and MUMPS. Output is appended.
+    """
+    sys.stdout.flush()
+    sys.stderr.flush()
+    saved_out, saved_err = os.dup(1), os.dup(2)
+    dest = os.open(
+        os.devnull if target is None else target,
+        os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+        0o644,
+    )
+    try:
+        os.dup2(dest, 1)
+        os.dup2(dest, 2)
+        yield
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        # Flush C buffers before restoring, or block-buffered Ipopt/MUMPS output
+        # would spill out afterwards.
+        if _LIBC is not None:
+            try:
+                _LIBC.fflush(None)
+            except Exception:  # pragma: no cover - defensive
+                pass
+        os.dup2(saved_out, 1)
+        os.dup2(saved_err, 2)
+        os.close(saved_out)
+        os.close(saved_err)
+        os.close(dest)

--- a/gridfm_datakit/process/solver_output.py
+++ b/gridfm_datakit/process/solver_output.py
@@ -107,14 +107,17 @@ class SolverOutputConfig:
         return _MEMENTO_LEVEL[self.verbosity]
 
     @property
+    def to_console(self) -> bool:
+        return self.log_dir is None and self.verbosity > SolverVerbosity.SILENT
+
+    @property
     def silence_powermodels(self) -> bool:
         # PowerModels logs through its own Memento logger, which ignores the
         # root level, so silence() is the only thing that quiets its Info/Warn.
-        return self.verbosity < SolverVerbosity.INFO
-
-    @property
-    def to_console(self) -> bool:
-        return self.log_dir is None and self.verbosity > SolverVerbosity.SILENT
+        # Silence it unless output is explicitly headed for the console -- when
+        # logging to files, its chatter still leaks to stdout from the fast
+        # (non-redirected) solver paths.
+        return not self.to_console
 
     def log_file(self, name: str) -> Optional[str]:
         """Per-process log path for solver ``name`` (e.g. "opf"), or None."""

--- a/gridfm_datakit/process/solver_output.py
+++ b/gridfm_datakit/process/solver_output.py
@@ -1,10 +1,31 @@
-"""Centralized control of Julia/PowerModels/Ipopt solver output.
+"""Controlled routing of sub-module output (Ipopt, PowerModels, MUMPS, ...).
 
-One :class:`SolverOutputConfig` maps a single verbosity level onto the three
-places solver chatter comes from: Ipopt's ``print_level``, PowerModels'
-``silence()``, and Memento's root logger. :func:`redirect_c_stdio` is the
-companion for the cases the loggers can't reach -- Ipopt and MUMPS write
-straight to file descriptors 1/2, so only an OS-level dup2 captures them.
+The problem this solves: several sub-modules print on their own terms. Ipopt
+and MUMPS write straight to file descriptors 1/2 from C/Fortran; PowerModels
+logs through its own Memento logger; Pkg prints activation banners. There is no
+single Python or Julia switch that quiets or captures all of them.
+
+This module gives every noisy sub-system **one well-defined path**:
+
+* Policy -- :class:`SolverOutputConfig` maps a single :class:`SolverVerbosity`
+  onto the knobs each sub-system understands (Ipopt ``print_level``, Memento
+  level, whether to call ``PowerModels.silence()``).
+* Routing -- a :class:`LogChannel` is a *named* destination (console, a file,
+  or discard). A :class:`LogRouter` owns one channel per sub-system for the
+  current process.
+* Capture -- a single fd-level context manager (:func:`redirect_fds`) moves the
+  bytes. Because Ipopt/MUMPS bypass Python's ``sys.stdout``, only an OS-level
+  ``dup2`` reliably captures them, so this is the *only* capture mechanism --
+  it is applied uniformly around every solve rather than compiled into the
+  Julia solver definitions.
+
+Typical wiring (see ``process_network.init_julia`` / ``process.solvers``)::
+
+    router = build_router(config)        # once per worker process
+    set_active_router(router)            # publish it process-wide
+    ...
+    with solver_capture("opf"):          # around each jl.run_opf(...) call
+        result = jl.run_opf(case_file)
 """
 
 from __future__ import annotations
@@ -12,15 +33,21 @@ from __future__ import annotations
 import ctypes
 import os
 import sys
-from contextlib import contextmanager
+import threading
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Iterator, Optional
+from typing import Dict, Iterator, Optional
 
 try:
     _LIBC: Optional[ctypes.CDLL] = ctypes.CDLL(None)
 except Exception:  # pragma: no cover - platform without a loadable libc
     _LIBC = None
+
+# dup2 swaps process-global fds 1/2, so it must not run concurrently from two
+# threads. An RLock also lets a single thread nest captures (warm-up inside a
+# solve) without self-deadlock; save/restore is per level so nesting is sound.
+_FD_LOCK = threading.RLock()
 
 
 class SolverVerbosity(IntEnum):
@@ -49,6 +76,8 @@ class SolverVerbosity(IntEnum):
 
 
 # Ipopt print levels run 0..12; 5 already prints the full iteration table.
+# Ipopt has no true error/warning granularity, so ERROR/WARNING collapse to 0 --
+# to actually see anything from Ipopt you need INFO or louder.
 _IPOPT_PRINT_LEVEL = {
     SolverVerbosity.SILENT: 0,
     SolverVerbosity.ERROR: 0,
@@ -57,8 +86,11 @@ _IPOPT_PRINT_LEVEL = {
     SolverVerbosity.DEBUG: 5,
 }
 
+# Memento levels, quietest to loudest: emergency > ... > error > warn > info >
+# debug > not_set. "not_set" means "inherit" (i.e. NOT silent), so SILENT maps
+# to the highest level that suppresses everything the solvers emit.
 _MEMENTO_LEVEL = {
-    SolverVerbosity.SILENT: "not_set",
+    SolverVerbosity.SILENT: "emergency",
     SolverVerbosity.ERROR: "error",
     SolverVerbosity.WARNING: "warn",
     SolverVerbosity.INFO: "info",
@@ -68,10 +100,14 @@ _MEMENTO_LEVEL = {
 
 @dataclass(frozen=True)
 class SolverOutputConfig:
-    """How much the solvers should print, and where it goes.
+    """Policy: how loud the solvers are, and whether output goes to files.
 
-    With ``log_dir`` set, output is captured to per-process files; otherwise it
-    reaches the console (or is dropped when SILENT).
+    This is a pure value object -- it knows nothing about multiprocessing or
+    where individual log files live. Use :func:`build_router` to turn it into
+    the per-process :class:`LogRouter` that owns the actual destinations.
+
+    With ``log_dir`` set, solver output is captured to per-process files;
+    otherwise it reaches the console (or is discarded when SILENT).
     """
 
     verbosity: SolverVerbosity = SolverVerbosity.SILENT
@@ -108,58 +144,163 @@ class SolverOutputConfig:
 
     @property
     def to_console(self) -> bool:
+        """True when output should stream to the live console (not files)."""
         return self.log_dir is None and self.verbosity > SolverVerbosity.SILENT
 
     @property
     def silence_powermodels(self) -> bool:
-        # PowerModels logs through its own Memento logger, which ignores the
-        # root level, so silence() is the only thing that quiets its Info/Warn.
-        # Silence it unless output is explicitly headed for the console -- when
-        # logging to files, its chatter still leaks to stdout from the fast
-        # (non-redirected) solver paths.
-        return not self.to_console
+        """Whether to call ``PowerModels.silence()``.
 
-    def log_file(self, name: str) -> Optional[str]:
-        """Per-process log path for solver ``name`` (e.g. "opf"), or None."""
-        if self.log_dir is None:
-            return None
-        import multiprocessing
+        Driven purely by the level: PowerModels' own Info/Warn is wanted only
+        at INFO or louder. This is independent of console-vs-file, so file logs
+        at DEBUG genuinely contain PowerModels output (the old code silenced it
+        whenever logging to files, defeating the logs).
+        """
+        return self.verbosity < SolverVerbosity.INFO
 
-        proc = multiprocessing.current_process().name
-        return os.path.join(self.log_dir, f"{name}_{proc}.log").replace("\\", "/")
+
+@dataclass(frozen=True)
+class LogChannel:
+    """A named output destination for one sub-system.
+
+    Exactly one of the three modes applies:
+
+    * ``to_console`` -- pass through; the sub-system writes to the real
+      stdout/stderr (used when the user asked for live output).
+    * ``path`` set -- capture fd 1/2 into this file (append).
+    * neither -- discard (route fd 1/2 to /dev/null).
+    """
+
+    name: str
+    path: Optional[str] = None
+    to_console: bool = False
+
+    def capture(self):
+        """Context manager routing fd 1/2 for the duration of a call."""
+        if self.to_console:
+            return nullcontext()
+        return redirect_fds(self.path)
+
+    def write_header(self, text: str) -> None:
+        """Emit a human-readable marker to wherever this channel points."""
+        if self.to_console:
+            print(text, end="" if text.endswith("\n") else "\n", flush=True)
+        elif self.path is not None:
+            with open(self.path, "a") as f:
+                f.write(text if text.endswith("\n") else text + "\n")
+        # discard -> nothing
+
+
+# Sub-systems that get their own channel. Extend this list to bring any new
+# noisy object under the same controlled routing.
+SOLVER_CHANNELS = ("opf", "dcopf", "pf", "dcpf", "warmup")
+
+
+class LogRouter:
+    """Per-process registry mapping sub-system name -> :class:`LogChannel`."""
+
+    def __init__(self, channels: Dict[str, LogChannel]):
+        self._channels = dict(channels)
+
+    def channel(self, name: str) -> LogChannel:
+        # Unknown names discard by default rather than leaking to the console.
+        return self._channels.get(name, LogChannel(name))
+
+    def capture(self, name: str):
+        return self.channel(name).capture()
+
+
+def _process_log_path(log_dir: str, name: str) -> str:
+    """Per-process log file for sub-system ``name`` under ``log_dir``."""
+    import multiprocessing
+
+    proc = multiprocessing.current_process().name
+    return os.path.join(log_dir, f"{name}_{proc}.log").replace("\\", "/")
+
+
+def build_router(
+    config: SolverOutputConfig,
+    names: "tuple[str, ...]" = SOLVER_CHANNELS,
+) -> LogRouter:
+    """Resolve a :class:`SolverOutputConfig` into concrete per-process channels.
+
+    This is where the (impure) multiprocessing-aware file naming lives, keeping
+    :class:`SolverOutputConfig` a pure policy object.
+    """
+    channels: Dict[str, LogChannel] = {}
+    for name in names:
+        if config.log_dir is not None:
+            channels[name] = LogChannel(
+                name,
+                path=_process_log_path(config.log_dir, name),
+            )
+        else:
+            channels[name] = LogChannel(name, to_console=config.to_console)
+    return LogRouter(channels)
+
+
+# --- Process-wide active router -------------------------------------------
+# Set once per worker in init_julia; read at each solve site in process.solvers
+# so the capture policy travels with the process, not the call signature.
+_active_router: Optional[LogRouter] = None
+
+
+def set_active_router(router: Optional[LogRouter]) -> None:
+    global _active_router
+    _active_router = router
+
+
+def get_active_router() -> Optional[LogRouter]:
+    return _active_router
+
+
+def solver_capture(name: str):
+    """Capture fd 1/2 for sub-system ``name`` via the active router.
+
+    A no-op when no router is installed, so solver functions stay usable
+    outside the generation pipeline (e.g. ad-hoc scripts, tests).
+    """
+    router = _active_router
+    return router.capture(name) if router is not None else nullcontext()
 
 
 @contextmanager
-def redirect_c_stdio(target: Optional[str]) -> Iterator[None]:
+def redirect_fds(target: Optional[str]) -> Iterator[None]:
     """Redirect fd 1 and 2 to ``target`` (a file) or /dev/null (when None).
 
     Works at the file-descriptor level, so unlike ``redirect_stdout`` it also
     captures C/Fortran output from Ipopt and MUMPS. Output is appended.
+    Serialised (and nestable) via ``_FD_LOCK``.
     """
-    sys.stdout.flush()
-    sys.stderr.flush()
-    saved_out, saved_err = os.dup(1), os.dup(2)
-    dest = os.open(
-        os.devnull if target is None else target,
-        os.O_WRONLY | os.O_CREAT | os.O_APPEND,
-        0o644,
-    )
-    try:
-        os.dup2(dest, 1)
-        os.dup2(dest, 2)
-        yield
-    finally:
+    with _FD_LOCK:
         sys.stdout.flush()
         sys.stderr.flush()
-        # Flush C buffers before restoring, or block-buffered Ipopt/MUMPS output
-        # would spill out afterwards.
-        if _LIBC is not None:
-            try:
-                _LIBC.fflush(None)
-            except Exception:  # pragma: no cover - defensive
-                pass
-        os.dup2(saved_out, 1)
-        os.dup2(saved_err, 2)
-        os.close(saved_out)
-        os.close(saved_err)
-        os.close(dest)
+        saved_out, saved_err = os.dup(1), os.dup(2)
+        dest = os.open(
+            os.devnull if target is None else target,
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            0o644,
+        )
+        try:
+            os.dup2(dest, 1)
+            os.dup2(dest, 2)
+            yield
+        finally:
+            sys.stdout.flush()
+            sys.stderr.flush()
+            # Flush C buffers before restoring, or block-buffered Ipopt/MUMPS
+            # output would spill out afterwards.
+            if _LIBC is not None:
+                try:
+                    _LIBC.fflush(None)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+            os.dup2(saved_out, 1)
+            os.dup2(saved_err, 2)
+            os.close(saved_out)
+            os.close(saved_err)
+            os.close(dest)
+
+
+# Backwards-compatible alias for the previous public name.
+redirect_c_stdio = redirect_fds

--- a/gridfm_datakit/process/solvers.py
+++ b/gridfm_datakit/process/solvers.py
@@ -12,6 +12,7 @@ import tempfile
 import os
 from typing import Any, Dict
 from gridfm_datakit.network import Network
+from gridfm_datakit.process.solver_output import solver_capture
 from typing import Union
 
 
@@ -36,7 +37,8 @@ def run_opf(net: Network, jl: Any) -> Dict[str, Any]:
         # Save network to temporary file
         net.to_mpc(temp_filename)
 
-        result = jl.run_opf(temp_filename)
+        with solver_capture("opf"):
+            result = jl.run_opf(temp_filename)
 
         if str(result["termination_status"]) != "LOCALLY_SOLVED":
             raise RuntimeError(f"OPF did not converge: {result['termination_status']}")
@@ -79,7 +81,8 @@ def run_pf(net: Network, jl: Any, fast: Union[bool, None] = None) -> Dict[str, A
         net.to_mpc(temp_filename)
 
         # Run PF
-        result = jl.run_pf_fast(temp_filename) if fast else jl.run_pf(temp_filename)
+        with solver_capture("pf"):
+            result = jl.run_pf_fast(temp_filename) if fast else jl.run_pf(temp_filename)
         if (
             fast
             and str(result["termination_status"]) != "True"
@@ -126,7 +129,10 @@ def run_dcpf(net: Network, jl: Any, fast: Union[bool, None] = None) -> Dict[str,
         net.to_mpc(temp_filename)
 
         # Run DCPF (fast or standard)
-        result = jl.run_dcpf_fast(temp_filename) if fast else jl.run_dcpf(temp_filename)
+        with solver_capture("dcpf"):
+            result = (
+                jl.run_dcpf_fast(temp_filename) if fast else jl.run_dcpf(temp_filename)
+            )
 
         if (
             fast
@@ -172,7 +178,8 @@ def run_dcopf(net: Network, jl: Any) -> Dict[str, Any]:
         net.to_mpc(temp_filename)
 
         # Run DC OPF
-        result = jl.run_dcopf(temp_filename)
+        with solver_capture("dcopf"):
+            result = jl.run_dcopf(temp_filename)
 
         if str(result["termination_status"]) != "LOCALLY_SOLVED":
             raise RuntimeError(

--- a/scripts/compare_parquet_files.py
+++ b/scripts/compare_parquet_files.py
@@ -51,7 +51,7 @@ settings:
   overwrite: true # If true, overwrites existing files, if false, appends to files
   mode: "pf" # Mode of the script; options: pf, opf. pf: power flow data where one or more operating limits – the inequality constraints defined in OPF, e.g., voltage magnitude or branch limits – may be violated. opf:  generates datapoints for training OPF solvers, with cost-optimal dispatches that satisfy all operating limits (OPF-feasible)
   include_dc_res: true # If true, also stores the results of dc power flow or dc optimal power flow
-  enable_solver_logs: true # If true, write OPF/PF logs to {data_dir}/solver_log; PF fast and DCPF fast do not log.
+  enable_solver_logs: true # If true, write OPF/PF/DCPF logs (incl. fast paths) to {data_dir}/solver_log.
   pf_fast: true # Whether to use fast PF solver by default (compute_ac_pf from powermodels.jl); if false, uses Ipopt-based PF. Some networks (typically large ones e.g. case10000_goc) do not work with pf_fast: true. pf_fast is faster and more accurate than the Ipopt-based PF.
   dcpf_fast: true # Whether to use fast DCPF solver by default (compute_dc_pf from PowerModels.jl)
   max_iter: 200 # Max iterations for Ipopt-based solvers

--- a/scripts/config/Texas2k_case1_2016summerpeak.yaml
+++ b/scripts/config/Texas2k_case1_2016summerpeak.yaml
@@ -41,7 +41,7 @@ settings:
   overwrite: true # If true, overwrites existing files, if false, appends to files
   mode: "pf" # Mode of the script; options: pf, opf. pf: power flow data where one or more operating limits – the inequality constraints defined in OPF, e.g., voltage magnitude or branch limits – may be violated. opf:  generates datapoints for training OPF solvers, with cost-optimal dispatches that satisfy all operating limits (OPF-feasible)
   include_dc_res: true # If true, also stores the results of dc power flow or dc optimal power flow
-  enable_solver_logs: false # If true, write OPF/PF logs to {data_dir}/solver_log; PF fast and DCPF fast do not log.
+  enable_solver_logs: false # If true, write OPF/PF/DCPF logs (incl. fast paths) to {data_dir}/solver_log.
   pf_fast: true # Whether to use fast PF solver by default (compute_ac_pf from powermodels.jl); if false, uses Ipopt-based PF. Some networks (typically large ones e.g. case10000_goc) do not work with pf_fast: true. pf_fast is faster and more accurate than the Ipopt-based PF.
   dcpf_fast: true # Whether to use fast DCPF solver by default (compute_dc_pf from PowerModels.jl)
   max_iter: 200 # Max iterations for Ipopt-based solvers

--- a/scripts/config/default.yaml
+++ b/scripts/config/default.yaml
@@ -41,7 +41,7 @@ settings:
   overwrite: true # If true, overwrites existing files, if false, appends to files
   mode: "pf" # Mode of the script; options: pf, opf. pf: power flow data where one or more operating limits – the inequality constraints defined in OPF, e.g., voltage magnitude or branch limits – may be violated. opf:  generates datapoints for training OPF solvers, with cost-optimal dispatches that satisfy all operating limits (OPF-feasible)
   include_dc_res: true # If true, also stores the results of dc power flow or dc optimal power flow
-  enable_solver_logs: true # If true, write OPF/PF logs to {data_dir}/solver_log; PF fast and DCPF fast do not log.
+  enable_solver_logs: true # If true, write OPF/PF/DCPF logs (incl. fast paths) to {data_dir}/solver_log.
   pf_fast: true # Whether to use fast PF solver by default (compute_ac_pf from powermodels.jl); if false, uses Ipopt-based PF. Some networks (typically large ones e.g. case10000_goc) do not work with pf_fast: true. pf_fast is faster and more accurate than the Ipopt-based PF.
   dcpf_fast: true # Whether to use fast DCPF solver by default (compute_dc_pf from PowerModels.jl)
   max_iter: 200 # Max iterations for Ipopt-based solvers

--- a/tests/test_solver_output.py
+++ b/tests/test_solver_output.py
@@ -1,0 +1,118 @@
+"""Tests for the pure-Python parts of solver output management.
+
+The Julia wiring is exercised by the generation tests.
+"""
+
+import ctypes
+import os
+
+import pytest
+
+from gridfm_datakit.process.solver_output import (
+    SolverOutputConfig,
+    SolverVerbosity,
+    redirect_c_stdio,
+)
+
+
+class TestSolverVerbosity:
+    def test_parse_accepts_name_int_and_enum(self):
+        assert SolverVerbosity.parse("debug") == SolverVerbosity.DEBUG
+        assert SolverVerbosity.parse("  Silent ") == SolverVerbosity.SILENT
+        assert SolverVerbosity.parse(2) == SolverVerbosity.WARNING
+        assert SolverVerbosity.parse(SolverVerbosity.INFO) == SolverVerbosity.INFO
+
+    def test_parse_rejects_unknown(self):
+        with pytest.raises(ValueError):
+            SolverVerbosity.parse("loud")
+
+
+class TestSolverOutputConfig:
+    def test_ipopt_and_memento_mapping(self):
+        silent = SolverOutputConfig(SolverVerbosity.SILENT)
+        assert silent.ipopt_print_level == 0
+        assert silent.memento_level == "not_set"
+
+        debug = SolverOutputConfig(SolverVerbosity.DEBUG)
+        assert debug.ipopt_print_level == 5
+        assert debug.memento_level == "debug"
+
+    def test_to_console_only_when_loud_and_no_log_dir(self):
+        assert SolverOutputConfig(SolverVerbosity.INFO).to_console is True
+        assert SolverOutputConfig(SolverVerbosity.SILENT).to_console is False
+        assert (
+            SolverOutputConfig(SolverVerbosity.INFO, log_dir="/tmp").to_console is False
+        )
+
+    def test_log_file_none_without_log_dir(self):
+        assert SolverOutputConfig(SolverVerbosity.DEBUG).log_file("opf") is None
+
+    def test_log_file_is_per_process(self, tmp_path):
+        cfg = SolverOutputConfig(SolverVerbosity.DEBUG, log_dir=str(tmp_path))
+        path = cfg.log_file("opf")
+        assert path is not None
+        assert path.startswith(str(tmp_path).replace("\\", "/"))
+        assert os.path.basename(path).startswith("opf_")
+
+    def test_from_settings_backcompat_defaults(self):
+        # logs disabled -> silent, no dir
+        cfg = SolverOutputConfig.from_settings(enable_solver_logs=False, log_dir="/x")
+        assert cfg.verbosity == SolverVerbosity.SILENT
+        assert cfg.log_dir is None
+
+        # logs enabled -> debug, keep dir
+        cfg = SolverOutputConfig.from_settings(enable_solver_logs=True, log_dir="/x")
+        assert cfg.verbosity == SolverVerbosity.DEBUG
+        assert cfg.log_dir == "/x"
+
+        # explicit verbosity wins
+        cfg = SolverOutputConfig.from_settings(
+            verbosity="warning",
+            enable_solver_logs=True,
+            log_dir="/x",
+        )
+        assert cfg.verbosity == SolverVerbosity.WARNING
+
+
+class TestRedirectCStdio:
+    # Write straight to fd 1/2 (and via libc), not print(): the whole point is
+    # capturing fd-level output that bypasses Python's sys.stdout.
+
+    def test_redirects_c_level_writes_to_file(self, tmp_path, capfd):
+        libc = ctypes.CDLL(None)
+        log = tmp_path / "out.log"
+
+        with redirect_c_stdio(str(log)):
+            os.write(1, b"fd-level stdout line\n")
+            os.write(2, b"fd-level stderr line\n")
+            libc.puts(b"c-level line")
+
+        contents = log.read_text()
+        assert "fd-level stdout line" in contents
+        assert "fd-level stderr line" in contents
+        assert "c-level line" in contents
+        # Nothing leaked to the real stdout/stderr.
+        captured = capfd.readouterr()
+        assert captured.out == "" and captured.err == ""
+
+    def test_discard_to_devnull(self, capfd):
+        with redirect_c_stdio(None):
+            os.write(1, b"should be discarded\n")
+        assert capfd.readouterr().out == ""
+
+    def test_restores_fds_afterwards(self, tmp_path, capfd):
+        log = tmp_path / "out.log"
+        with redirect_c_stdio(str(log)):
+            os.write(1, b"inside\n")
+        os.write(1, b"outside\n")
+        # 'outside' reaches the real stdout again; 'inside' went to the file.
+        assert capfd.readouterr().out.strip() == "outside"
+        assert "inside" in log.read_text()
+
+    def test_appends_rather_than_truncates(self, tmp_path):
+        log = tmp_path / "out.log"
+        log.write_text("preexisting\n")
+        with redirect_c_stdio(str(log)):
+            os.write(1, b"added\n")
+        text = log.read_text()
+        assert "preexisting" in text and "added" in text

--- a/tests/test_solver_output.py
+++ b/tests/test_solver_output.py
@@ -44,6 +44,18 @@ class TestSolverOutputConfig:
             SolverOutputConfig(SolverVerbosity.INFO, log_dir="/tmp").to_console is False
         )
 
+    def test_silence_powermodels_unless_console(self):
+        # Silenced when SILENT or when logging to files; shown only on console.
+        assert SolverOutputConfig(SolverVerbosity.SILENT).silence_powermodels is True
+        assert (
+            SolverOutputConfig(
+                SolverVerbosity.DEBUG,
+                log_dir="/tmp",
+            ).silence_powermodels
+            is True
+        )
+        assert SolverOutputConfig(SolverVerbosity.INFO).silence_powermodels is False
+
     def test_log_file_none_without_log_dir(self):
         assert SolverOutputConfig(SolverVerbosity.DEBUG).log_file("opf") is None
 

--- a/tests/test_solver_output.py
+++ b/tests/test_solver_output.py
@@ -9,9 +9,12 @@ import os
 import pytest
 
 from gridfm_datakit.process.solver_output import (
+    LogChannel,
+    LogRouter,
     SolverOutputConfig,
     SolverVerbosity,
-    redirect_c_stdio,
+    build_router,
+    redirect_fds,
 )
 
 
@@ -31,7 +34,9 @@ class TestSolverOutputConfig:
     def test_ipopt_and_memento_mapping(self):
         silent = SolverOutputConfig(SolverVerbosity.SILENT)
         assert silent.ipopt_print_level == 0
-        assert silent.memento_level == "not_set"
+        # "not_set" means "inherit" in Memento (i.e. not silent); SILENT must map
+        # to a level that actually suppresses everything.
+        assert silent.memento_level == "emergency"
 
         debug = SolverOutputConfig(SolverVerbosity.DEBUG)
         assert debug.ipopt_print_level == 5
@@ -44,27 +49,19 @@ class TestSolverOutputConfig:
             SolverOutputConfig(SolverVerbosity.INFO, log_dir="/tmp").to_console is False
         )
 
-    def test_silence_powermodels_unless_console(self):
-        # Silenced when SILENT or when logging to files; shown only on console.
+    def test_silence_powermodels_driven_by_level_only(self):
+        # Silenced below INFO, regardless of console vs file destination -- so
+        # DEBUG file logs genuinely contain PowerModels output.
         assert SolverOutputConfig(SolverVerbosity.SILENT).silence_powermodels is True
+        assert SolverOutputConfig(SolverVerbosity.WARNING).silence_powermodels is True
         assert (
             SolverOutputConfig(
                 SolverVerbosity.DEBUG,
                 log_dir="/tmp",
             ).silence_powermodels
-            is True
+            is False
         )
         assert SolverOutputConfig(SolverVerbosity.INFO).silence_powermodels is False
-
-    def test_log_file_none_without_log_dir(self):
-        assert SolverOutputConfig(SolverVerbosity.DEBUG).log_file("opf") is None
-
-    def test_log_file_is_per_process(self, tmp_path):
-        cfg = SolverOutputConfig(SolverVerbosity.DEBUG, log_dir=str(tmp_path))
-        path = cfg.log_file("opf")
-        assert path is not None
-        assert path.startswith(str(tmp_path).replace("\\", "/"))
-        assert os.path.basename(path).startswith("opf_")
 
     def test_from_settings_backcompat_defaults(self):
         # logs disabled -> silent, no dir
@@ -94,7 +91,7 @@ class TestRedirectCStdio:
         libc = ctypes.CDLL(None)
         log = tmp_path / "out.log"
 
-        with redirect_c_stdio(str(log)):
+        with redirect_fds(str(log)):
             os.write(1, b"fd-level stdout line\n")
             os.write(2, b"fd-level stderr line\n")
             libc.puts(b"c-level line")
@@ -108,13 +105,13 @@ class TestRedirectCStdio:
         assert captured.out == "" and captured.err == ""
 
     def test_discard_to_devnull(self, capfd):
-        with redirect_c_stdio(None):
+        with redirect_fds(None):
             os.write(1, b"should be discarded\n")
         assert capfd.readouterr().out == ""
 
     def test_restores_fds_afterwards(self, tmp_path, capfd):
         log = tmp_path / "out.log"
-        with redirect_c_stdio(str(log)):
+        with redirect_fds(str(log)):
             os.write(1, b"inside\n")
         os.write(1, b"outside\n")
         # 'outside' reaches the real stdout again; 'inside' went to the file.
@@ -124,7 +121,75 @@ class TestRedirectCStdio:
     def test_appends_rather_than_truncates(self, tmp_path):
         log = tmp_path / "out.log"
         log.write_text("preexisting\n")
-        with redirect_c_stdio(str(log)):
+        with redirect_fds(str(log)):
             os.write(1, b"added\n")
         text = log.read_text()
         assert "preexisting" in text and "added" in text
+
+    def test_nested_capture_restores_correctly(self, tmp_path, capfd):
+        inner = tmp_path / "inner.log"
+        with redirect_fds(str(tmp_path / "outer.log")):
+            with redirect_fds(str(inner)):
+                os.write(1, b"deep\n")
+            os.write(1, b"middle\n")
+        os.write(1, b"surface\n")
+        assert "deep" in inner.read_text()
+        assert "middle" in (tmp_path / "outer.log").read_text()
+        assert capfd.readouterr().out.strip() == "surface"
+
+
+class TestLogChannel:
+    def test_console_channel_passes_through(self, tmp_path, capfd):
+        ch = LogChannel("opf", to_console=True)
+        with ch.capture():
+            os.write(1, b"visible\n")
+        assert "visible" in capfd.readouterr().out
+
+    def test_file_channel_captures_to_path(self, tmp_path, capfd):
+        log = tmp_path / "opf.log"
+        ch = LogChannel("opf", path=str(log))
+        with ch.capture():
+            os.write(1, b"to file\n")
+        assert "to file" in log.read_text()
+        assert capfd.readouterr().out == ""
+
+    def test_discard_channel_swallows_output(self, capfd):
+        ch = LogChannel("opf")  # no path, not console -> discard
+        with ch.capture():
+            os.write(1, b"gone\n")
+        assert capfd.readouterr().out == ""
+
+    def test_write_header_routes_with_capture(self, tmp_path, capfd):
+        log = tmp_path / "opf.log"
+        LogChannel("opf", path=str(log)).write_header("== warm ==")
+        assert "== warm ==" in log.read_text()
+        # Discard channel writes its header nowhere.
+        LogChannel("opf").write_header("== warm ==")
+        assert capfd.readouterr().out == ""
+
+
+class TestLogRouter:
+    def test_build_router_files_when_log_dir_set(self, tmp_path, capfd):
+        cfg = SolverOutputConfig(SolverVerbosity.DEBUG, log_dir=str(tmp_path))
+        router = build_router(cfg)
+        with router.capture("opf"):
+            os.write(1, b"opf output\n")
+        # A file named opf_<process>.log holds it; nothing hit the console.
+        opf_files = list(tmp_path.glob("opf_*.log"))
+        assert opf_files and "opf output" in opf_files[0].read_text()
+        assert capfd.readouterr().out == ""
+
+    def test_build_router_discards_when_silent(self, capfd):
+        router = build_router(SolverOutputConfig(SolverVerbosity.SILENT))
+        with router.capture("pf"):
+            os.write(1, b"noise\n")
+        assert capfd.readouterr().out == ""
+
+    def test_unknown_channel_discards(self, capfd):
+        router = build_router(SolverOutputConfig(SolverVerbosity.INFO))
+        # INFO with no log_dir -> known channels pass through to console, but an
+        # unknown name defaults to discard rather than leaking.
+        assert isinstance(router, LogRouter)
+        with router.capture("mystery"):
+            os.write(1, b"secret\n")
+        assert capfd.readouterr().out == ""


### PR DESCRIPTION
`test_all_perturbation_combinations` failed intermittently on CI with `[Errno 11] write could not complete without blocking`. The cause was the **volume** of Ipopt/PowerModels output overflowing CI's non-blocking stdout pipe — not blocking mode itself (an earlier `set_stdio_blocking` attempt didn't help).

Fix: manage solver output centrally via `SolverOutputConfig` and default to silent:
- Ipopt `print_level=0`
- `PowerModels.silence()` (the root Memento level doesn't reach PowerModels' own logger)
- discard the one-time Ipopt license banner via fd-level redirection (`redirect_c_stdio`, which captures C/Fortran output that Julia's `redirect_stdout` misses)
- drop the hardcoded `print_level=5` in the load upper-limit search — the main flood source

`enable_solver_logs=true` still captures full solver output to per-process log files. Adds unit tests for the verbosity mapping and fd redirection.
