### PR TITLE
Speed up CI Julia setup with pinned deps and a working depot cache

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -59,19 +59,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Julia packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.julia
-          key: julia-packages-${{ runner.os }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            julia-packages-${{ runner.os }}-
-
       - name: Install Julia 1.12
         uses: julia-actions/setup-julia@v1
         with:
           version: '1.12'
+
+      # Cache the whole Julia depot (downloaded packages, artifacts and, most
+      # importantly, the precompile cache). Keyed on the pinned solver versions
+      # so it only rebuilds when juliapkg.json changes.
+      - name: Cache Julia depot
+        uses: actions/cache@v4
+        with:
+          path: ~/.julia
+          key: julia-depot-${{ runner.os }}-julia1.12-${{ hashFiles('gridfm_datakit/juliapkg.json') }}
+          restore-keys: |
+            julia-depot-${{ runner.os }}-julia1.12-
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v4
@@ -79,7 +81,7 @@ jobs:
           python-version: '3.12'
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}
@@ -97,12 +99,13 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install -e ".[test]"
 
-      - name: Run Julia setup (PowerModels)
-        env:
-          JULIA_PKG_SERVER: ""
+      # Resolve and precompile the pinned Julia packages from juliapkg.json.
+      # On a cache hit this is near-instant; on a miss it populates the depot
+      # cache for subsequent runs.
+      - name: Set up Julia packages (PowerModels)
         run: |
           source .venv/bin/activate
-          gridfm_datakit setup_pm
+          python -c "import juliacall"
 
       - name: Unit tests
         run: |

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -100,13 +100,15 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install -e ".[test]"
 
-      # Resolve and precompile the pinned Julia packages from juliapkg.json.
-      # On a cache hit this is near-instant; on a miss it populates the depot
-      # cache for subsequent runs.
+      # Resolve, install and precompile the pinned Julia packages from
+      # juliapkg.json. Forcing `using` (not just `import juliacall`) precompiles
+      # PowerModels/Ipopt/Memento into the depot so the cache captures it and the
+      # first test doesn't pay for it; it also fails fast here if the pinned
+      # versions don't resolve together. Near-instant on a cache hit.
       - name: Set up Julia packages (PowerModels)
         run: |
           source .venv/bin/activate
-          python -c "import juliacall"
+          python -c "from juliacall import Main as jl; jl.seval('using PowerModels, Ipopt, Memento')"
 
       - name: Unit tests
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include gridfm_datakit/load_profiles *.csv
 recursive-include gridfm_datakit/grids *.m
 recursive-include gridfm_datakit/process *.m
+include gridfm_datakit/juliapkg.json

--- a/gridfm_datakit/juliapkg.json
+++ b/gridfm_datakit/juliapkg.json
@@ -1,5 +1,4 @@
 {
-    "julia": "1.12",
     "packages": {
         "PowerModels": {
             "uuid": "c36e90e8-916a-50a6-bd94-075b64ef4655",

--- a/gridfm_datakit/juliapkg.json
+++ b/gridfm_datakit/juliapkg.json
@@ -1,0 +1,17 @@
+{
+    "julia": "1.12",
+    "packages": {
+        "PowerModels": {
+            "uuid": "c36e90e8-916a-50a6-bd94-075b64ef4655",
+            "version": "=0.21.6"
+        },
+        "Ipopt": {
+            "uuid": "b6b21f68-93f8-5de0-b562-5493be1d77c9",
+            "version": "=1.15.0"
+        },
+        "Memento": {
+            "uuid": "f28f55f0-a522-5efc-85c2-fe41dfb9b2d9",
+            "version": "=1.5.0"
+        }
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,9 @@ dependencies = [
     "ipywidgets",
     "ipyfilechooser",
     "scipy",
-    # Pinned: juliacall 0.9.35 caps Julia at <=1.11, which conflicts with the
-    # Julia 1.12 used here. 0.9.34 supports Julia 1.12.
-    "juliacall==0.9.34",
+    # Floor, not exact pin: 0.9.34+ supports Julia >=1.10.3 (incl. 1.12). The
+    # reproducible Julia environment is pinned in gridfm_datakit/juliapkg.json.
+    "juliacall>=0.9.34",
     "networkx",
     "tqdm",
     "pyarrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,9 @@ dependencies = [
     "ipywidgets",
     "ipyfilechooser",
     "scipy",
-    "juliacall",
+    # Pinned: juliacall 0.9.35 caps Julia at <=1.11, which conflicts with the
+    # Julia 1.12 used here. 0.9.34 supports Julia 1.12.
+    "juliacall==0.9.34",
     "networkx",
     "tqdm",
     "pyarrow",


### PR DESCRIPTION
## Problem

The `pytests` job spent ~5 min every run on **"Run Julia setup (PowerModels)"** — `gridfm_datakit setup_pm` does `Pkg.add`, re-resolving and precompiling PowerModels/Ipopt from scratch. The Julia cache never helped: its key was `hashFiles('**/Project.toml')`, but no `Project.toml` exists, so the key was empty and restore was a 0s miss with no save.

## Fix

- **`gridfm_datakit/juliapkg.json`** declares the Julia deps with exact pins (PowerModels `=0.21.6`, Ipopt `=1.15.0`, Memento `=1.5.0`). juliacall installs them reproducibly on `import juliacall`; no runtime `Pkg.add`.
- **Cache the whole `~/.julia` depot** (downloaded packages + precompile cache), keyed on `juliapkg.json`, so repeat runs reuse precompilation.
- Replace the `setup_pm` step with an `import juliacall` warmup; add `juliapkg.json` to `MANIFEST.in`; bump `actions/cache@v3 → v4`.

## Expected impact

- First run: still ~5 min (cold cache) — it populates the cache.
- Subsequent runs / PRs (once on `main`): the 5-min setup collapses to seconds on a cache hit.
