### PR TITLE
Add configurable outage-count sampling for random topology perturbations

### DIFF
--- a/docs/manual/getting_started.md
+++ b/docs/manual/getting_started.md
@@ -52,6 +52,7 @@ topology_perturbation:
   k: 2 # Maximum number of components to drop in each perturbation
   n_topology_variants: 10 # Number of unique perturbed topologies per scenario
   elements: [branch, gen] # elements to perturb. options: branch, gen
+  outage_count_probabilities: [0.1, 0.8, 0.1] # Optional: P(N-0), P(N-1), P(N-2)
 
 generation_perturbation:
   type: "cost_permutation" # Type of generation perturbation; options: cost_permutation, cost_perturbation, none

--- a/docs/manual/topology_perturbations.md
+++ b/docs/manual/topology_perturbations.md
@@ -16,11 +16,11 @@ Example:
 
 ```yaml
 topology_perturbation:
-	type: "random"
-	k: 2
-	n_topology_variants: 20
-	elements: [branch, gen]
-	outage_count_probabilities: [0.1, 0.8, 0.1]
+  type: "random"
+  k: 2
+  n_topology_variants: 20
+  elements: [branch, gen]
+  outage_count_probabilities: [0.1, 0.8, 0.1]
 ```
 
 This requests approximately 10% N-0, 80% N-1, and 10% N-2 attempted perturbations. Realized proportions can differ slightly because infeasible sampled topologies are rejected.

--- a/docs/manual/topology_perturbations.md
+++ b/docs/manual/topology_perturbations.md
@@ -7,15 +7,28 @@ Topology perturbations generate variations of the original network by altering i
 The module provides three topology perturbation strategies:
 
 - `NoPerturbationGenerator` yields the original topology without changes. It is useful for baseline comparisons and debugging.
-
 - `NMinusKGenerator` generates all possible combinations of up to *k* components (lines and transformers) being out of service. Only feasible topologies with no unsupplied buses are returned.
-
 - `RandomComponentDropGenerator` randomly generates a specified number of feasible topologies by disabling up to *k* randomly selected components, including lines, transformers, generators, and static generators.
+
+For `type: random`, you can optionally control the outage-count mix directly with a probability vector whose index `i` represents the probability of sampling `i` outages.
+
+Example:
+
+```yaml
+topology_perturbation:
+	type: "random"
+	k: 2
+	n_topology_variants: 20
+	elements: [branch, gen]
+	outage_count_probabilities: [0.1, 0.8, 0.1]
+```
+
+This requests approximately 10% N-0, 80% N-1, and 10% N-2 attempted perturbations. Realized proportions can differ slightly because infeasible sampled topologies are rejected.
 
 ## Comparison of Perturbation Strategies
 
-| Feature                            | `NoPerturbationGenerator` | `NMinusKGenerator`        | `RandomComponentDropGenerator` |
-|-----------------------------------|----------------------------|---------------------------|--------------------------------|
-| **Number of topologies**          | 1 (original)               | All feasible (up to k elements lost)    | User-defined         |
-| **Component types supported**     | –                          | Lines, Transformers       | Lines, Transformers, Gens, Sgens |
-| **Randomized generation**         | ❌ No                      | ❌ No                     | ✅ Yes                         |
+| Feature                             | `NoPerturbationGenerator` | `NMinusKGenerator`                 | `RandomComponentDropGenerator` |
+| ----------------------------------- | --------------------------- | ------------------------------------ | -------------------------------- |
+| **Number of topologies**      | 1 (original)                | All feasible (up to k elements lost) | User-defined                     |
+| **Component types supported** | –                          | Lines, Transformers                  | Lines, Transformers, Gens, Sgens |
+| **Randomized generation**     | ❌ No                       | ❌ No                                | ✅ Yes                           |

--- a/gridfm_datakit/interactive.py
+++ b/gridfm_datakit/interactive.py
@@ -120,7 +120,7 @@ def _parse_outage_count_probabilities(raw_value: str) -> List[float] | None:
         return [float(part) for part in parts]
     except ValueError as exc:
         raise ValueError(
-            "Outage count probabilities must be a comma-separated list of numbers.",
+            "Outage count probabilities must be a comma-separated list of numbers that sum to 1.0.",
         ) from exc
 
 

--- a/gridfm_datakit/interactive.py
+++ b/gridfm_datakit/interactive.py
@@ -101,7 +101,7 @@ def create_config() -> Dict[str, Any]:
         },
     }
     probabilities = _parse_outage_count_probabilities(
-        outage_count_probabilities.value.strip()
+        outage_count_probabilities.value.strip(),
     )
     if probabilities is not None:
         config["topology_perturbation"]["outage_count_probabilities"] = probabilities
@@ -120,7 +120,7 @@ def _parse_outage_count_probabilities(raw_value: str) -> List[float] | None:
         return [float(part) for part in parts]
     except ValueError as exc:
         raise ValueError(
-            "Outage count probabilities must be a comma-separated list of numbers."
+            "Outage count probabilities must be a comma-separated list of numbers.",
         ) from exc
 
 
@@ -354,7 +354,12 @@ def interactive_interface() -> None:
 
     # Topology Perturbation Configuration
 
-    global k, n_topology_variants, perturbation_type, elements, outage_count_probabilities
+    global \
+        k, \
+        n_topology_variants, \
+        perturbation_type, \
+        elements, \
+        outage_count_probabilities
     k = widgets.IntSlider(
         value=1,
         min=1,
@@ -660,7 +665,7 @@ def interactive_interface() -> None:
             elements,
             outage_count_probabilities,
             outage_count_probabilities_help,
-        ]
+        ],
     )
 
     # Function to update topology perturbation component visibility

--- a/gridfm_datakit/interactive.py
+++ b/gridfm_datakit/interactive.py
@@ -100,7 +100,28 @@ def create_config() -> Dict[str, Any]:
             "seed": None,  # seed is not used in the interactive interface
         },
     }
+    probabilities = _parse_outage_count_probabilities(
+        outage_count_probabilities.value.strip()
+    )
+    if probabilities is not None:
+        config["topology_perturbation"]["outage_count_probabilities"] = probabilities
     return config
+
+
+def _parse_outage_count_probabilities(raw_value: str) -> List[float] | None:
+    """Parse a comma-separated outage-count probability vector from the UI."""
+
+    if not raw_value:
+        return None
+    parts = [part.strip() for part in raw_value.split(",") if part.strip()]
+    if not parts:
+        return None
+    try:
+        return [float(part) for part in parts]
+    except ValueError as exc:
+        raise ValueError(
+            "Outage count probabilities must be a comma-separated list of numbers."
+        ) from exc
 
 
 def interactive_interface() -> None:
@@ -333,7 +354,7 @@ def interactive_interface() -> None:
 
     # Topology Perturbation Configuration
 
-    global k, n_topology_variants, perturbation_type, elements
+    global k, n_topology_variants, perturbation_type, elements, outage_count_probabilities
     k = widgets.IntSlider(
         value=1,
         min=1,
@@ -377,6 +398,18 @@ def interactive_interface() -> None:
         description="Elements to Drop:",
         style={"description_width": "150px"},
         layout=widgets.Layout(width="550px", height="120px"),
+    )
+
+    outage_count_probabilities = widgets.Text(
+        value="",
+        description="Outage Prob.:",
+        placeholder="e.g. 0.1, 0.8, 0.1 for N-0/N-1/N-2",
+        style={"description_width": "150px"},
+        layout=widgets.Layout(width="550px"),
+    )
+
+    outage_count_probabilities_help = widgets.HTML(
+        "<p style='margin: 0 0 0 150px; color: #666;'>If not included, the default is random between 1 and k.</p>",
     )
 
     # Generation Configuration
@@ -620,7 +653,15 @@ def interactive_interface() -> None:
     )
 
     # Create containers for topology perturbation components
-    topology_components_container = widgets.VBox([k, n_topology_variants, elements])
+    topology_components_container = widgets.VBox(
+        [
+            k,
+            n_topology_variants,
+            elements,
+            outage_count_probabilities,
+            outage_count_probabilities_help,
+        ]
+    )
 
     # Function to update topology perturbation component visibility
     def update_topology_perturbation_visibility(*args):
@@ -632,7 +673,13 @@ def interactive_interface() -> None:
             topology_components_container.layout.display = "block"
         else:
             # For random, show all components
-            topology_components_container.children = [k, n_topology_variants, elements]
+            topology_components_container.children = [
+                k,
+                n_topology_variants,
+                elements,
+                outage_count_probabilities,
+                outage_count_probabilities_help,
+            ]
             topology_components_container.layout.display = "block"
 
     perturbation_type.observe(update_topology_perturbation_visibility, names="value")

--- a/gridfm_datakit/perturbations/topology_perturbation.py
+++ b/gridfm_datakit/perturbations/topology_perturbation.py
@@ -169,9 +169,7 @@ class RandomComponentDropGenerator(TopologyGenerator):
         # Preserve the current 1..k uniform sampling when no explicit count
         # probabilities are provided, but allow configurable sampling over 0..k.
         self.outage_count_values, self.outage_count_probabilities = (
-            self._normalize_outage_count_probabilities(
-                k, outage_count_probabilities
-            )
+            self._normalize_outage_count_probabilities(k, outage_count_probabilities)
         )
 
     def generate(
@@ -228,7 +226,7 @@ class RandomComponentDropGenerator(TopologyGenerator):
             np.random.choice(
                 self.outage_count_values,
                 p=self.outage_count_probabilities,
-            )
+            ),
         )
 
     @staticmethod
@@ -248,7 +246,7 @@ class RandomComponentDropGenerator(TopologyGenerator):
                 count = int(raw_count)
                 if count < 0 or count > k:
                     raise ValueError(
-                        f"Outage count {count} is outside the supported range 0..{k}."
+                        f"Outage count {count} is outside the supported range 0..{k}.",
                     )
                 probability_values[count] = float(raw_probability)
             return RandomComponentDropGenerator._validate_outage_count_probabilities(
@@ -259,11 +257,11 @@ class RandomComponentDropGenerator(TopologyGenerator):
         probability_values = np.asarray(probabilities, dtype=float)
         if probability_values.ndim != 1:
             raise ValueError(
-                "outage_count_probabilities must be a one-dimensional sequence."
+                "outage_count_probabilities must be a one-dimensional sequence.",
             )
         if len(probability_values) != k + 1:
             raise ValueError(
-                "outage_count_probabilities sequence must have length k + 1 so index i maps to i outages."
+                "outage_count_probabilities sequence must have length k + 1 so index i maps to i outages.",
             )
         allowed_counts = np.arange(k + 1, dtype=int)
         return RandomComponentDropGenerator._validate_outage_count_probabilities(
@@ -281,11 +279,11 @@ class RandomComponentDropGenerator(TopologyGenerator):
         total_probability = float(probability_values.sum())
         if not np.isclose(total_probability, 1.0, atol=1e-8):
             raise ValueError(
-                "outage_count_probabilities must sum to 1.0 within numerical tolerance."
+                "outage_count_probabilities must sum to 1.0 within numerical tolerance.",
             )
         if not np.any(probability_values > 0.0):
             raise ValueError(
-                "outage_count_probabilities must contain at least one positive value."
+                "outage_count_probabilities must contain at least one positive value.",
             )
         return counts.astype(int, copy=True), probability_values.astype(
             float,

--- a/gridfm_datakit/perturbations/topology_perturbation.py
+++ b/gridfm_datakit/perturbations/topology_perturbation.py
@@ -3,7 +3,7 @@ import copy
 from itertools import combinations
 from abc import ABC, abstractmethod
 import warnings
-from typing import Generator, List, Union
+from typing import Generator, List, Mapping, Sequence, Union
 from gridfm_datakit.network import Network
 from gridfm_datakit.utils.idx_gen import GEN_BUS
 
@@ -137,6 +137,7 @@ class RandomComponentDropGenerator(TopologyGenerator):
         k: int,
         base_net: Network,
         elements: List[str] = ["branch", "gen"],
+        outage_count_probabilities: Sequence[float] | Mapping[int, float] | None = None,
     ) -> None:
         """Initialize the random component drop generator.
 
@@ -145,6 +146,8 @@ class RandomComponentDropGenerator(TopologyGenerator):
             k: Maximum number of components to drop.
             base_net: The base power network.
             elements: List of element types to consider for dropping.
+            outage_count_probabilities: Optional probabilities over outage counts.
+                Index or key `i` means probability of sampling `i` outages.
         """
         super().__init__()
         self.n_topology_variants = n_topology_variants
@@ -162,6 +165,14 @@ class RandomComponentDropGenerator(TopologyGenerator):
                 for idx in base_net.idx_gens_in_service
                 if base_net.gens[idx, GEN_BUS] != base_net.ref_bus_idx
             )
+
+        # Preserve the current 1..k uniform sampling when no explicit count
+        # probabilities are provided, but allow configurable sampling over 0..k.
+        self.outage_count_values, self.outage_count_probabilities = (
+            self._normalize_outage_count_probabilities(
+                k, outage_count_probabilities
+            )
+        )
 
     def generate(
         self,
@@ -181,11 +192,7 @@ class RandomComponentDropGenerator(TopologyGenerator):
         while n_generated_topologies < self.n_topology_variants:
             perturbed_topology = copy.deepcopy(net)
 
-            # draw the number of components to drop from a uniform distribution
-            r = np.random.randint(
-                1,
-                self.k + 1,
-            )  # TODO: decide if we want to be able to set 0 components out of service
+            r = self._sample_outage_count()
 
             # Randomly select r<=k components to drop
             components = tuple(
@@ -213,3 +220,74 @@ class RandomComponentDropGenerator(TopologyGenerator):
             if perturbed_topology.check_single_connected_component():
                 yield perturbed_topology
                 n_generated_topologies += 1
+
+    def _sample_outage_count(self) -> int:
+        if self.outage_count_probabilities is None:
+            return int(np.random.randint(1, self.k + 1))
+        return int(
+            np.random.choice(
+                self.outage_count_values,
+                p=self.outage_count_probabilities,
+            )
+        )
+
+    @staticmethod
+    def _normalize_outage_count_probabilities(
+        k: int,
+        probabilities: Sequence[float] | Mapping[int, float] | None,
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Validate optional outage-count probabilities for random topology sampling."""
+
+        if probabilities is None:
+            return None, None
+
+        if isinstance(probabilities, Mapping):
+            allowed_counts = np.arange(k + 1, dtype=int)
+            probability_values = np.zeros(k + 1, dtype=float)
+            for raw_count, raw_probability in probabilities.items():
+                count = int(raw_count)
+                if count < 0 or count > k:
+                    raise ValueError(
+                        f"Outage count {count} is outside the supported range 0..{k}."
+                    )
+                probability_values[count] = float(raw_probability)
+            return RandomComponentDropGenerator._validate_outage_count_probabilities(
+                allowed_counts,
+                probability_values,
+            )
+
+        probability_values = np.asarray(probabilities, dtype=float)
+        if probability_values.ndim != 1:
+            raise ValueError(
+                "outage_count_probabilities must be a one-dimensional sequence."
+            )
+        if len(probability_values) != k + 1:
+            raise ValueError(
+                "outage_count_probabilities sequence must have length k + 1 so index i maps to i outages."
+            )
+        allowed_counts = np.arange(k + 1, dtype=int)
+        return RandomComponentDropGenerator._validate_outage_count_probabilities(
+            allowed_counts,
+            probability_values,
+        )
+
+    @staticmethod
+    def _validate_outage_count_probabilities(
+        counts: np.ndarray,
+        probability_values: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if np.any(probability_values < 0.0):
+            raise ValueError("outage_count_probabilities must be non-negative.")
+        total_probability = float(probability_values.sum())
+        if not np.isclose(total_probability, 1.0, atol=1e-8):
+            raise ValueError(
+                "outage_count_probabilities must sum to 1.0 within numerical tolerance."
+            )
+        if not np.any(probability_values > 0.0):
+            raise ValueError(
+                "outage_count_probabilities must contain at least one positive value."
+            )
+        return counts.astype(int, copy=True), probability_values.astype(
+            float,
+            copy=True,
+        )

--- a/gridfm_datakit/perturbations/topology_perturbation.py
+++ b/gridfm_datakit/perturbations/topology_perturbation.py
@@ -138,6 +138,7 @@ class RandomComponentDropGenerator(TopologyGenerator):
         base_net: Network,
         elements: List[str] = ["branch", "gen"],
         outage_count_probabilities: Sequence[float] | Mapping[int, float] | None = None,
+        max_generation_attempts: int | None = None,
     ) -> None:
         """Initialize the random component drop generator.
 
@@ -148,6 +149,10 @@ class RandomComponentDropGenerator(TopologyGenerator):
             elements: List of element types to consider for dropping.
             outage_count_probabilities: Optional probabilities over outage counts.
                 Index or key `i` means probability of sampling `i` outages.
+            max_generation_attempts: Optional cap on sampled topology attempts
+                before failing if too many sampled topologies are infeasible.
+                If not provided, a default limit of
+                ``max(500, 50 * n_topology_variants)`` is used.
         """
         super().__init__()
         self.n_topology_variants = n_topology_variants
@@ -171,6 +176,10 @@ class RandomComponentDropGenerator(TopologyGenerator):
         self.outage_count_values, self.outage_count_probabilities = (
             self._normalize_outage_count_probabilities(k, outage_count_probabilities)
         )
+        self.max_generation_attempts = self._resolve_max_generation_attempts(
+            n_topology_variants,
+            max_generation_attempts,
+        )
 
     def generate(
         self,
@@ -185,9 +194,18 @@ class RandomComponentDropGenerator(TopologyGenerator):
             A perturbed network topology.
         """
         n_generated_topologies = 0
+        n_attempts = 0
 
         # Stop after we generated n_topology_variants
         while n_generated_topologies < self.n_topology_variants:
+            if n_attempts >= self.max_generation_attempts:
+                raise RuntimeError(
+                    "Unable to generate "
+                    f"{self.n_topology_variants} feasible topologies within "
+                    f"{self.max_generation_attempts} attempts. "
+                    "Consider reducing k or relaxing outage_count_probabilities.",
+                )
+            n_attempts += 1
             perturbed_topology = copy.deepcopy(net)
 
             r = self._sample_outage_count()
@@ -228,6 +246,17 @@ class RandomComponentDropGenerator(TopologyGenerator):
                 p=self.outage_count_probabilities,
             ),
         )
+
+    @staticmethod
+    def _resolve_max_generation_attempts(
+        n_topology_variants: int,
+        max_generation_attempts: int | None,
+    ) -> int:
+        if max_generation_attempts is None:
+            return max(500, 50 * max(1, int(n_topology_variants)))
+        if int(max_generation_attempts) <= 0:
+            raise ValueError("max_generation_attempts must be greater than 0.")
+        return int(max_generation_attempts)
 
     @staticmethod
     def _normalize_outage_count_probabilities(

--- a/gridfm_datakit/utils/param_handler.py
+++ b/gridfm_datakit/utils/param_handler.py
@@ -231,12 +231,16 @@ def initialize_topology_generator(
             args.k,
             base_net,
             elements,
+            getattr(args, "outage_count_probabilities", None),
         )
         used_args = {
             "n_topology_variants": args.n_topology_variants,
             "k": args.k,
             "base_net": base_net,
             "elements": elements,
+            "outage_count_probabilities": getattr(
+                args, "outage_count_probabilities", None
+            ),
         }
 
     elif args.type == "none":

--- a/gridfm_datakit/utils/param_handler.py
+++ b/gridfm_datakit/utils/param_handler.py
@@ -239,7 +239,9 @@ def initialize_topology_generator(
             "base_net": base_net,
             "elements": elements,
             "outage_count_probabilities": getattr(
-                args, "outage_count_probabilities", None
+                args,
+                "outage_count_probabilities",
+                None,
             ),
         }
 

--- a/scripts/config/Texas2k_case1_2016summerpeak.yaml
+++ b/scripts/config/Texas2k_case1_2016summerpeak.yaml
@@ -23,6 +23,10 @@ topology_perturbation:
   k: 1 # Maximum number of components to drop in each perturbation
   n_topology_variants: 20 # Number of unique perturbed topologies per scenario
   elements: [branch, gen] # elements to perturb. options: branch, gen
+  # Optional for type: "random": entry i is the probability of sampling i outages.
+  # If omitted, the generator samples uniformly between 1 and k.
+  # Example for k: 1 -> 10% N-0 and 90% N-1.
+  # outage_count_probabilities: [0.1, 0.9]
 
 generation_perturbation:
   type: "cost_permutation" # Type of generation perturbation; options: cost_permutation, cost_perturbation, none

--- a/scripts/config/default.yaml
+++ b/scripts/config/default.yaml
@@ -23,6 +23,10 @@ topology_perturbation:
   k: 1 # Maximum number of components to drop in each perturbation
   n_topology_variants: 20 # Number of unique perturbed topologies per scenario
   elements: [branch, gen] # elements to perturb. options: branch, gen
+  # Optional for type: "random": entry i is the probability of sampling i outages.
+  # If omitted, the generator samples uniformly between 1 and k.
+  # Example for k: 1 -> 10% N-0 and 90% N-1.
+  # outage_count_probabilities: [0.1, 0.9]
 
 generation_perturbation:
   type: "cost_permutation" # Type of generation perturbation; options: cost_permutation, cost_perturbation, none

--- a/scripts/config/default.yaml
+++ b/scripts/config/default.yaml
@@ -7,7 +7,7 @@ network:
 load:
   generator: "agg_load_profile" # Name of the load generator; options: agg_load_profile, powergraph
   agg_profile: "default" # Name of the aggregated load profile
-  scenarios: 10000 # Number of different load scenarios to generate
+  scenarios: 1000 # Number of different load scenarios to generate
   # WARNING: the following parameters are only used if generator is "agg_load_profile"
   # if using generator "powergraph", these parameters are ignored
   sigma: 0.2 # max local noise
@@ -20,13 +20,13 @@ load:
 topology_perturbation:
   type: "random" # Type of topology generator; options: n_minus_k, random, none
   # WARNING: the following parameters are only used if type is not "none"
-  k: 1 # Maximum number of components to drop in each perturbation
-  n_topology_variants: 20 # Number of unique perturbed topologies per scenario
+  k: 2 # Maximum number of components to drop in each perturbation
+  n_topology_variants: 50 # Number of unique perturbed topologies per scenario
   elements: [branch, gen] # elements to perturb. options: branch, gen
   # Optional for type: "random": entry i is the probability of sampling i outages.
   # If omitted, the generator samples uniformly between 1 and k.
   # Example for k: 1 -> 10% N-0 and 90% N-1.
-  # outage_count_probabilities: [0.1, 0.9]
+  outage_count_probabilities: [0.2, 0.4, 0.4]
 
 generation_perturbation:
   type: "cost_permutation" # Type of generation perturbation; options: cost_permutation, cost_perturbation, none

--- a/scripts/config/default.yaml
+++ b/scripts/config/default.yaml
@@ -7,7 +7,7 @@ network:
 load:
   generator: "agg_load_profile" # Name of the load generator; options: agg_load_profile, powergraph
   agg_profile: "default" # Name of the aggregated load profile
-  scenarios: 1000 # Number of different load scenarios to generate
+  scenarios: 10000 # Number of different load scenarios to generate
   # WARNING: the following parameters are only used if generator is "agg_load_profile"
   # if using generator "powergraph", these parameters are ignored
   sigma: 0.2 # max local noise
@@ -20,13 +20,14 @@ load:
 topology_perturbation:
   type: "random" # Type of topology generator; options: n_minus_k, random, none
   # WARNING: the following parameters are only used if type is not "none"
-  k: 2 # Maximum number of components to drop in each perturbation
-  n_topology_variants: 50 # Number of unique perturbed topologies per scenario
+  k: 1 # Maximum number of components to drop in each perturbation
+  n_topology_variants: 20 # Number of unique perturbed topologies per scenario
   elements: [branch, gen] # elements to perturb. options: branch, gen
-  # Optional for type: "random": entry i is the probability of sampling i outages.
-  # If omitted, the generator samples uniformly between 1 and k.
+  # Optional for type: "random": if provided, entry i is the probability of sampling i outages.
+  # If provided, the generator samples over 0..k; otherwise it samples uniformly between 1 and k.
+  # Use decimal probabilities in YAML, not fraction expressions.
   # Example for k: 1 -> 10% N-0 and 90% N-1.
-  outage_count_probabilities: [0.2, 0.4, 0.4]
+  # outage_count_probabilities: [0.1, 0.9]
 
 generation_perturbation:
   type: "cost_permutation" # Type of generation perturbation; options: cost_permutation, cost_perturbation, none

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -6,6 +6,8 @@ Tests the Network class and load functions with matpowercaseframes integration
 import pytest
 import numpy as np
 from gridfm_datakit.network import load_net_from_pglib, Network
+from gridfm_datakit.utils.idx_brch import BR_STATUS
+from gridfm_datakit.utils.idx_gen import GEN_STATUS
 
 
 class TestNetwork:
@@ -273,11 +275,11 @@ class TestNetwork:
 
         # Test deactivating a generator
         network.deactivate_gens(np.array([0]))
-        assert network.gens[0, 7] == 0, "Generator should be deactivated"
+        assert network.gens[0, GEN_STATUS] == 0, "Generator should be deactivated"
 
         # Test deactivating a branch
         network.deactivate_branches(np.array([0]))
-        assert network.branches[0, 10] == 0, "Branch should be deactivated"
+        assert network.branches[0, BR_STATUS] == 0, "Branch should be deactivated"
 
         # Test that idx_gens_in_service and idx_branches_in_service reflect the changes
         assert 0 not in network.idx_gens_in_service, (

--- a/tests/test_topology_perturbation.py
+++ b/tests/test_topology_perturbation.py
@@ -15,7 +15,7 @@ from gridfm_datakit.utils.param_handler import (
     NestedNamespace,
     initialize_topology_generator,
 )
-from gridfm_datakit.utils.idx_brch import F_BUS, T_BUS
+from gridfm_datakit.utils.idx_brch import BR_STATUS, F_BUS, T_BUS
 
 
 class TestTopologyPerturbation:
@@ -41,7 +41,7 @@ class TestTopologyPerturbation:
 
         # Verify original network is unchanged
         np.testing.assert_array_equal(
-            original_network.branches[:, 10],
+            original_network.branches[:, BR_STATUS],
             original_branch_status,
             "Original network branch status should be unchanged",
         )
@@ -79,7 +79,7 @@ class TestTopologyPerturbation:
         network_states = []
         for network in perturbed_networks:
             state = {
-                "branch_status": network.branches[:, 10].copy(),  # BR_STATUS
+                "branch_status": network.branches[:, BR_STATUS].copy(),  # BR_STATUS
                 "gen_status": network.gens[:, 7].copy(),  # GEN_STATUS
             }
             network_states.append(state)
@@ -133,14 +133,14 @@ class TestTopologyPerturbation:
         test_network = load_net_from_pglib("case24_ieee_rts")
 
         # Get original branch status
-        original_branch_status = test_network.branches[:, 10].copy()
+        original_branch_status = test_network.branches[:, BR_STATUS].copy()
 
         # Deactivate some branches
         branches_to_deactivate = np.array([0, 1, 2])
         test_network.deactivate_branches(branches_to_deactivate)
 
         # Verify branches are deactivated
-        assert np.all(test_network.branches[branches_to_deactivate, 10] == 0), (
+        assert np.all(test_network.branches[branches_to_deactivate, BR_STATUS] == 0), (
             "Branches should be deactivated"
         )
 
@@ -150,7 +150,7 @@ class TestTopologyPerturbation:
             branches_to_deactivate,
         )
         np.testing.assert_array_equal(
-            test_network.branches[other_branches, 10],
+            test_network.branches[other_branches, BR_STATUS],
             original_branch_status[other_branches],
             "Other branches should be unchanged",
         )
@@ -232,7 +232,7 @@ class TestTopologyPerturbation:
         copied_network.deactivate_gens([0])
 
         # Verify original is unchanged
-        assert np.all(original_network.branches[:, 10] == 1), (
+        assert np.all(original_network.branches[:, BR_STATUS] == 1), (
             "Original network branches should be in service"
         )
         assert np.all(original_network.gens[:, 7] == 1), (
@@ -240,10 +240,10 @@ class TestTopologyPerturbation:
         )
 
         # Verify copy is modified
-        assert copied_network.branches[0, 10] == 0, (
+        assert copied_network.branches[0, BR_STATUS] == 0, (
             "Copied network branch 0 should be out of service"
         )
-        assert copied_network.branches[1, 10] == 0, (
+        assert copied_network.branches[1, BR_STATUS] == 0, (
             "Copied network branch 1 should be out of service"
         )
         assert copied_network.gens[0, 7] == 0, (
@@ -325,8 +325,8 @@ class TestTopologyPerturbation:
         assert len(perturbed_networks) == 3
         for network in perturbed_networks:
             np.testing.assert_array_equal(
-                network.branches[:, 10],
-                original_network.branches[:, 10],
+                network.branches[:, BR_STATUS],
+                original_network.branches[:, BR_STATUS],
                 "N-0 sampling should preserve branch statuses",
             )
             np.testing.assert_array_equal(
@@ -351,11 +351,39 @@ class TestTopologyPerturbation:
 
         assert len(perturbed_networks) == 4
         for network in perturbed_networks:
-            branch_outages = int(np.sum(network.branches[:, 10] == 0))
+            branch_outages = int(np.sum(network.branches[:, BR_STATUS] == 0))
             gen_outages = int(np.sum(network.gens[:, 7] == 0))
             assert branch_outages + gen_outages == 2, (
                 "Each sampled topology should contain exactly two outages"
             )
+
+    def test_random_component_drop_generator_caps_infeasible_attempts(
+        self,
+        monkeypatch,
+    ):
+        """Test that infeasible sampling does not loop forever."""
+        original_network = load_net_from_pglib("case24_ieee_rts")
+
+        random_generator = RandomComponentDropGenerator(
+            n_topology_variants=1,
+            k=2,
+            base_net=original_network,
+            elements=["branch", "gen"],
+            outage_count_probabilities=[0.0, 0.0, 1.0],
+            max_generation_attempts=3,
+        )
+
+        monkeypatch.setattr(
+            type(original_network),
+            "check_single_connected_component",
+            lambda self: False,
+        )
+
+        with pytest.raises(
+            RuntimeError,
+            match="Unable to generate 1 feasible topologies",
+        ):
+            list(random_generator.generate(original_network))
 
     def test_random_component_drop_generator_rejects_invalid_probabilities(self):
         """Test validation for outage-count probabilities."""
@@ -376,6 +404,44 @@ class TestTopologyPerturbation:
                 base_net=original_network,
                 outage_count_probabilities=[0.5, 0.5],
             )
+
+    def test_random_component_drop_generator_accepts_probability_mapping(self):
+        """Test mapping-based outage-count probability input normalization."""
+        original_network = load_net_from_pglib("case24_ieee_rts")
+
+        random_generator = RandomComponentDropGenerator(
+            n_topology_variants=1,
+            k=2,
+            base_net=original_network,
+            outage_count_probabilities={2: 0.1, 0: 0.2, 1: 0.7},
+        )
+
+        np.testing.assert_array_equal(
+            random_generator.outage_count_values,
+            np.array([0, 1, 2]),
+        )
+        np.testing.assert_allclose(
+            random_generator.outage_count_probabilities,
+            np.array([0.2, 0.7, 0.1]),
+        )
+
+    def test_random_component_drop_generator_uses_default_attempt_cap(self):
+        """Test the default safeguard heuristic for infeasible sampling retries."""
+        original_network = load_net_from_pglib("case24_ieee_rts")
+
+        small_generator = RandomComponentDropGenerator(
+            n_topology_variants=1,
+            k=2,
+            base_net=original_network,
+        )
+        assert small_generator.max_generation_attempts == 500
+
+        larger_generator = RandomComponentDropGenerator(
+            n_topology_variants=20,
+            k=2,
+            base_net=original_network,
+        )
+        assert larger_generator.max_generation_attempts == 1000
 
     def test_initialize_topology_generator_passes_outage_probabilities(self):
         """Test config plumbing for outage-count probabilities."""
@@ -406,7 +472,7 @@ class TestTopologyPerturbation:
         original_network = load_net_from_pglib("case24_ieee_rts")
 
         # Store original state
-        original_branch_status = original_network.branches[:, 10].copy()
+        original_branch_status = original_network.branches[:, BR_STATUS].copy()
         original_gen_status = original_network.gens[:, 7].copy()
 
         # Test with NMinusKGenerator
@@ -415,7 +481,7 @@ class TestTopologyPerturbation:
 
         # Verify original is unchanged
         np.testing.assert_array_equal(
-            original_network.branches[:, 10],
+            original_network.branches[:, BR_STATUS],
             original_branch_status,
             "Original network should be unchanged after NMinusKGenerator",
         )
@@ -436,7 +502,7 @@ class TestTopologyPerturbation:
 
         # Verify original is unchanged
         np.testing.assert_array_equal(
-            original_network.branches[:, 10],
+            original_network.branches[:, BR_STATUS],
             original_branch_status,
             "Original network should be unchanged after RandomComponentDropGenerator",
         )
@@ -480,7 +546,7 @@ class TestTopologyPerturbation:
         test_network.deactivate_branches(np.array(branches_to_bus6))
 
         # Verify branches are deactivated
-        assert np.all(test_network.branches[branches_to_bus6, 10] == 0), (
+        assert np.all(test_network.branches[branches_to_bus6, BR_STATUS] == 0), (
             "All branches to bus 6 should be deactivated"
         )
 

--- a/tests/test_topology_perturbation.py
+++ b/tests/test_topology_perturbation.py
@@ -16,6 +16,7 @@ from gridfm_datakit.utils.param_handler import (
     initialize_topology_generator,
 )
 from gridfm_datakit.utils.idx_brch import BR_STATUS, F_BUS, T_BUS
+from gridfm_datakit.utils.idx_gen import GEN_STATUS
 
 
 class TestTopologyPerturbation:
@@ -29,9 +30,9 @@ class TestTopologyPerturbation:
         # Store original state
         original_branch_status = original_network.branches[
             :,
-            10,
+            BR_STATUS,
         ].copy()  # BR_STATUS column
-        original_gen_status = original_network.gens[:, 7].copy()  # GEN_STATUS column
+        original_gen_status = original_network.gens[:, GEN_STATUS].copy()
 
         # Create no perturbation generator
         no_perturbation_generator = NoPerturbationGenerator()
@@ -46,7 +47,7 @@ class TestTopologyPerturbation:
             "Original network branch status should be unchanged",
         )
         np.testing.assert_array_equal(
-            original_network.gens[:, 7],
+            original_network.gens[:, GEN_STATUS],
             original_gen_status,
             "Original network generator status should be unchanged",
         )
@@ -80,7 +81,7 @@ class TestTopologyPerturbation:
         for network in perturbed_networks:
             state = {
                 "branch_status": network.branches[:, BR_STATUS].copy(),  # BR_STATUS
-                "gen_status": network.gens[:, 7].copy(),  # GEN_STATUS
+                "gen_status": network.gens[:, GEN_STATUS].copy(),
             }
             network_states.append(state)
 
@@ -160,21 +161,21 @@ class TestTopologyPerturbation:
         test_network = load_net_from_pglib("case24_ieee_rts")
 
         # Get original generator status
-        original_gen_status = test_network.gens[:, 7].copy()
+        original_gen_status = test_network.gens[:, GEN_STATUS].copy()
 
         # Deactivate some generators
         gens_to_deactivate = np.array([0, 1])
         test_network.deactivate_gens(gens_to_deactivate)
 
         # Verify generators are deactivated
-        assert np.all(test_network.gens[gens_to_deactivate, 7] == 0), (
+        assert np.all(test_network.gens[gens_to_deactivate, GEN_STATUS] == 0), (
             "Generators should be deactivated"
         )
 
         # Verify other generators are unchanged
         other_gens = np.setdiff1d(np.arange(len(test_network.gens)), gens_to_deactivate)
         np.testing.assert_array_equal(
-            test_network.gens[other_gens, 7],
+            test_network.gens[other_gens, GEN_STATUS],
             original_gen_status[other_gens],
             "Other generators should be unchanged",
         )
@@ -235,7 +236,7 @@ class TestTopologyPerturbation:
         assert np.all(original_network.branches[:, BR_STATUS] == 1), (
             "Original network branches should be in service"
         )
-        assert np.all(original_network.gens[:, 7] == 1), (
+        assert np.all(original_network.gens[:, GEN_STATUS] == 1), (
             "Original network generators should be in service"
         )
 
@@ -246,7 +247,7 @@ class TestTopologyPerturbation:
         assert copied_network.branches[1, BR_STATUS] == 0, (
             "Copied network branch 1 should be out of service"
         )
-        assert copied_network.gens[0, 7] == 0, (
+        assert copied_network.gens[0, GEN_STATUS] == 0, (
             "Copied network generator 0 should be out of service"
         )
 
@@ -330,8 +331,8 @@ class TestTopologyPerturbation:
                 "N-0 sampling should preserve branch statuses",
             )
             np.testing.assert_array_equal(
-                network.gens[:, 7],
-                original_network.gens[:, 7],
+                network.gens[:, GEN_STATUS],
+                original_network.gens[:, GEN_STATUS],
                 "N-0 sampling should preserve generator statuses",
             )
 
@@ -352,7 +353,7 @@ class TestTopologyPerturbation:
         assert len(perturbed_networks) == 4
         for network in perturbed_networks:
             branch_outages = int(np.sum(network.branches[:, BR_STATUS] == 0))
-            gen_outages = int(np.sum(network.gens[:, 7] == 0))
+            gen_outages = int(np.sum(network.gens[:, GEN_STATUS] == 0))
             assert branch_outages + gen_outages == 2, (
                 "Each sampled topology should contain exactly two outages"
             )
@@ -473,7 +474,7 @@ class TestTopologyPerturbation:
 
         # Store original state
         original_branch_status = original_network.branches[:, BR_STATUS].copy()
-        original_gen_status = original_network.gens[:, 7].copy()
+        original_gen_status = original_network.gens[:, GEN_STATUS].copy()
 
         # Test with NMinusKGenerator
         n_minus_k_generator = NMinusKGenerator(k=1, base_net=original_network)
@@ -486,7 +487,7 @@ class TestTopologyPerturbation:
             "Original network should be unchanged after NMinusKGenerator",
         )
         np.testing.assert_array_equal(
-            original_network.gens[:, 7],
+            original_network.gens[:, GEN_STATUS],
             original_gen_status,
             "Original network should be unchanged after NMinusKGenerator",
         )
@@ -507,7 +508,7 @@ class TestTopologyPerturbation:
             "Original network should be unchanged after RandomComponentDropGenerator",
         )
         np.testing.assert_array_equal(
-            original_network.gens[:, 7],
+            original_network.gens[:, GEN_STATUS],
             original_gen_status,
             "Original network should be unchanged after RandomComponentDropGenerator",
         )

--- a/tests/test_topology_perturbation.py
+++ b/tests/test_topology_perturbation.py
@@ -11,6 +11,7 @@ from gridfm_datakit.perturbations.topology_perturbation import (
     NMinusKGenerator,
     RandomComponentDropGenerator,
 )
+from gridfm_datakit.utils.param_handler import NestedNamespace, initialize_topology_generator
 from gridfm_datakit.utils.idx_brch import F_BUS, T_BUS
 
 
@@ -303,6 +304,95 @@ class TestTopologyPerturbation:
             assert network.check_single_connected_component(), (
                 "All generated topologies should be connected"
             )
+
+    def test_random_component_drop_generator_supports_n0_sampling(self):
+        """Test that explicit probabilities can request N-0 topologies."""
+        original_network = load_net_from_pglib("case24_ieee_rts")
+
+        random_generator = RandomComponentDropGenerator(
+            n_topology_variants=3,
+            k=2,
+            base_net=original_network,
+            elements=["branch", "gen"],
+            outage_count_probabilities=[1.0, 0.0, 0.0],
+        )
+
+        perturbed_networks = list(random_generator.generate(original_network))
+
+        assert len(perturbed_networks) == 3
+        for network in perturbed_networks:
+            np.testing.assert_array_equal(
+                network.branches[:, 10],
+                original_network.branches[:, 10],
+                "N-0 sampling should preserve branch statuses",
+            )
+            np.testing.assert_array_equal(
+                network.gens[:, 7],
+                original_network.gens[:, 7],
+                "N-0 sampling should preserve generator statuses",
+            )
+
+    def test_random_component_drop_generator_respects_requested_outage_count(self):
+        """Test that deterministic outage-count probabilities force the sampled count."""
+        original_network = load_net_from_pglib("case24_ieee_rts")
+
+        random_generator = RandomComponentDropGenerator(
+            n_topology_variants=4,
+            k=2,
+            base_net=original_network,
+            elements=["branch", "gen"],
+            outage_count_probabilities=[0.0, 0.0, 1.0],
+        )
+
+        perturbed_networks = list(random_generator.generate(original_network))
+
+        assert len(perturbed_networks) == 4
+        for network in perturbed_networks:
+            branch_outages = int(np.sum(network.branches[:, 10] == 0))
+            gen_outages = int(np.sum(network.gens[:, 7] == 0))
+            assert branch_outages + gen_outages == 2, (
+                "Each sampled topology should contain exactly two outages"
+            )
+
+    def test_random_component_drop_generator_rejects_invalid_probabilities(self):
+        """Test validation for outage-count probabilities."""
+        original_network = load_net_from_pglib("case24_ieee_rts")
+
+        with pytest.raises(ValueError, match="sum to 1.0"):
+            RandomComponentDropGenerator(
+                n_topology_variants=1,
+                k=2,
+                base_net=original_network,
+                outage_count_probabilities=[0.2, 0.2, 0.2],
+            )
+
+        with pytest.raises(ValueError, match=r"length k \+ 1"):
+            RandomComponentDropGenerator(
+                n_topology_variants=1,
+                k=2,
+                base_net=original_network,
+                outage_count_probabilities=[0.5, 0.5],
+            )
+
+    def test_initialize_topology_generator_passes_outage_probabilities(self):
+        """Test config plumbing for outage-count probabilities."""
+        original_network = load_net_from_pglib("case24_ieee_rts")
+        args = NestedNamespace(
+            type="random",
+            n_topology_variants=2,
+            k=2,
+            elements=["branch", "gen"],
+            outage_count_probabilities=[0.1, 0.8, 0.1],
+        )
+
+        generator = initialize_topology_generator(args, original_network)
+
+        assert isinstance(generator, RandomComponentDropGenerator)
+        np.testing.assert_allclose(
+            generator.outage_count_probabilities,
+            np.array([0.1, 0.8, 0.1]),
+        )
+        np.testing.assert_array_equal(generator.outage_count_values, np.array([0, 1, 2]))
 
     def test_topology_generator_preserves_original(self):
         """Test that topology generators preserve the original network"""

--- a/tests/test_topology_perturbation.py
+++ b/tests/test_topology_perturbation.py
@@ -11,7 +11,10 @@ from gridfm_datakit.perturbations.topology_perturbation import (
     NMinusKGenerator,
     RandomComponentDropGenerator,
 )
-from gridfm_datakit.utils.param_handler import NestedNamespace, initialize_topology_generator
+from gridfm_datakit.utils.param_handler import (
+    NestedNamespace,
+    initialize_topology_generator,
+)
 from gridfm_datakit.utils.idx_brch import F_BUS, T_BUS
 
 
@@ -392,7 +395,10 @@ class TestTopologyPerturbation:
             generator.outage_count_probabilities,
             np.array([0.1, 0.8, 0.1]),
         )
-        np.testing.assert_array_equal(generator.outage_count_values, np.array([0, 1, 2]))
+        np.testing.assert_array_equal(
+            generator.outage_count_values,
+            np.array([0, 1, 2]),
+        )
 
     def test_topology_generator_preserves_original(self):
         """Test that topology generators preserve the original network"""


### PR DESCRIPTION
## Summary

This PR adds optional `outage_count_probabilities` support for `type: "random"` topology perturbations.

When provided, entry `i` represents the probability of sampling `i` outages.
When omitted, the existing default behavior is preserved: the generator samples uniformly between `1` and `k`.

## Changes

- add `outage_count_probabilities` support to `RandomComponentDropGenerator`
- validate probability shape, range, and normalization
- wire the option through topology generator initialization
- expose it in the interactive UI and generated YAML config
- update example configs and docs
- add focused topology perturbation tests

## Validation

- `python -m pytest tests/test_topology_perturbation.py -q`

## Notes

- the `Outage Prob.` UI field keeps the example placeholder
- if the field is left empty, the default remains random sampling between `1` and `k`