### PR TITLE
Fix import for juliapkg ≥0.1.24 (run_julia → run_script)

### DIFF
--- a/gridfm_datakit/network.py
+++ b/gridfm_datakit/network.py
@@ -17,7 +17,13 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 import requests
-from juliapkg.deps import executable, run_julia
+from juliapkg.deps import executable
+
+try:
+    # juliapkg >= 0.1.24 renamed run_julia to run_script (signature unchanged).
+    from juliapkg.deps import run_script as run_julia
+except ImportError:  # juliapkg < 0.1.24
+    from juliapkg.deps import run_julia
 from juliapkg.state import STATE
 from matpowercaseframes import CaseFrames
 from numpy import any, conj, exp, hstack, int64, nonzero, ones, pi, real


### PR DESCRIPTION
## What

Makes `gridfm_datakit/network.py` import the Julia script runner defensively:

```python
from juliapkg.deps import executable

try:
    # juliapkg >= 0.1.24 renamed run_julia to run_script (signature unchanged).
    from juliapkg.deps import run_script as run_julia
except ImportError:  # juliapkg < 0.1.24
    from juliapkg.deps import run_julia
```

## Why

`juliapkg >= 0.1.24` renamed `juliapkg.deps.run_julia` to `run_script` (identical signature). We pin `juliacall>=0.9.34` (floor, not exact), which pulls juliapkg in transitively, so a fresh install now resolves a juliapkg without `run_julia` and `import gridfm_datakit.network` fails with:

```
ImportError: cannot import name 'run_julia' from 'juliapkg.deps'
```

Environments with a cached juliapkg 0.1.23 keep working, which is why this only surfaced in fresh CI installs — including **gridfm-graphkit's `pytests`**, which import this package.

## Compatibility

No call-site changes needed — `run_script(script, executable=..., project=...)` has the same signature as the old `run_julia`. The fallback keeps older juliapkg working too.

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)