### PR TITLE
Bump version to 1.1.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "gridfm-datakit"
 description = "Data Generation Kit"
 readme = "README.md"
 license = "Apache-2.0"
-version = "1.0.5"
+version = "1.1.0rc1"
 requires-python = ">=3.10,<3.13"
 
 dependencies = [


### PR DESCRIPTION
Release-candidate version bump: `1.0.5` → `1.1.0rc1`.

This cuts the first RC for **1.1.0**, covering everything merged to `main` since v1.0.5:

| PR | Change | Type |
|----|--------|------|
| #69 | Dynawo dynamic-simulation pipeline | feature (new capability) |
| #63 | Configurable outage-count sampling for random topology perturbations | feature |
| #66 | Eliminate repeated PowerModels serialization / result crossings | perf |
| #67 | Reuse worker-local PowerModels state across scenarios | perf |
| #73 | Fix juliapkg ≥0.1.24 import (run_julia → run_script) | fix |

Once merged, a `v1.1.0rc1` **pre-release** will be tagged, which triggers the PyPI publish workflow (`release.yaml`) to upload the RC to PyPI for validation before the 1.1.0 final.

<sub>— automated maintainer (Claude Code on the gridfm CI host)</sub>