### PR TITLE
Fix the bandit scan skipping the whole package

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -19,19 +19,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: |
-            pip-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
-
-      - name: Run pre-commit
-        run: pre-commit run --verbose --all-files
+      - uses: pre-commit/action@v3.0.1
 
   security-test:
     runs-on: ubuntu-latest
@@ -39,21 +27,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache pip
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}
-          restore-keys: |
-            pip-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip wheel
-          pip install -e ".[dev]"
+      - name: Install bandit
+        run: pip install bandit
 
       - name: Security Checks
-        run: bandit --severity-level high .
+        run: bandit -r gridfm_datakit --severity-level high
 
   pytests:
     runs-on: ubuntu-latest

--- a/gridfm_datakit/dynamic/generate_dynamic.py
+++ b/gridfm_datakit/dynamic/generate_dynamic.py
@@ -761,6 +761,7 @@ class _DynamicDataWriter:
     def _write_metadata(self) -> None:
         config_hash = hashlib.md5(
             json.dumps(self.config.to_dict(), sort_keys=True, default=str).encode(),
+            usedforsecurity=False,
         ).hexdigest()
 
         metadata = {


### PR DESCRIPTION
`bandit --severity-level high .` does not recurse into a directory target. It prints a skip warning, reports zero lines of code and exits 0, so the security job has never scanned anything.

Scanning with `-r gridfm_datakit` surfaces one high severity finding, a B324 MD5 used as a config fingerprint in `_write_metadata`. That is not a security use, so it now passes `usedforsecurity=False`, which leaves the digest unchanged.

Both jobs also stop installing the package. pre-commit runs its hooks in isolated environments and bandit needs only itself, so neither job needs juliacall, numba, pandas, scipy or the Jupyter stack.
