### PR TITLE
Fix the PGLib sweep never testing OPF

### DIFF
--- a/gridfm_datakit/process/solvers.py
+++ b/gridfm_datakit/process/solvers.py
@@ -289,6 +289,7 @@ def compare_pf_results(
     net: Network,
     jl: Any,
     case_name: str,
+    *,
     fast: bool,
     solver_type: str = "pf",
 ) -> bool:
@@ -302,6 +303,7 @@ def compare_pf_results(
         net: A Network object containing the power system model.
         jl: Julia interface object for running power flow.
         case_name: Name of the case (e.g., 'case24_ieee_rts') to find the original file.
+        fast: Use the fast PF path. Only meaningful when solver_type is "pf".
         solver_type: Type of solver to test - "pf" for power flow or "opf" for optimal power flow.
 
     Returns:

--- a/tests/test_compare_pf_opf_results.py
+++ b/tests/test_compare_pf_opf_results.py
@@ -62,7 +62,13 @@ class TestComparePF_OPF_Results:
         )
 
         # Compare results
-        results_match = compare_pf_results(net, self.jl, case_name, fast, solver_type)
+        results_match = compare_pf_results(
+            net,
+            self.jl,
+            case_name,
+            fast=fast,
+            solver_type=solver_type,
+        )
 
         # Assert that results match
         assert results_match, (

--- a/tests/test_compare_pf_opf_results_all_pglib.py
+++ b/tests/test_compare_pf_opf_results_all_pglib.py
@@ -94,10 +94,14 @@ class TestComparePF_OPF_Results_AllPGLib:
         cls.jl = init_julia(max_iter=150)
 
     @pytest.mark.parametrize(
-        "case_name,solver_type",
-        [(c, s) for c in PGLIB_CASES for s in ("pf", "opf")],
+        "case_name,solver_type,fast",
+        [
+            (c, s, f)
+            for c in PGLIB_CASES
+            for s, f in (("pf", True), ("pf", False), ("opf", False))
+        ],
     )
-    def test_compare_results_all_pglib(self, case_name, solver_type):
+    def test_compare_results_all_pglib(self, case_name, solver_type, fast):
         solver_name = "PF" if solver_type == "pf" else "OPF"
         print(f"\n[All-PGLib] Testing {solver_name} result comparison for {case_name}…")
 
@@ -108,8 +112,15 @@ class TestComparePF_OPF_Results_AllPGLib:
         )
 
         # Compare results
-        results_match = compare_pf_results(net, self.jl, case_name, solver_type)
+        results_match = compare_pf_results(
+            net,
+            self.jl,
+            case_name,
+            fast=fast,
+            solver_type=solver_type,
+        )
 
         assert results_match, (
-            f"{solver_name} results from temp file don't match original case file for {case_name}"
+            f"{solver_name} results from temp file don't match original case file "
+            f"for {case_name} with fast={fast}"
         )


### PR DESCRIPTION
The exhaustive sweep parametrizes over pf and opf, then passes `solver_type` as the fourth positional argument. It binds to `fast`, both strings are truthy, and `solver_type` keeps its default. Every case ran the fast PF path twice and OPF was never exercised.

`fast` and `solver_type` are now keyword only, so the old call raises TypeError instead of misbinding silently. The sweep uses the same three combinations as the small grid test.
