### PR TITLE
Remove pathlib and numba, depend on pyyaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "numba",
   "numpy",
   "pandas",
-  "pathlib",
   "plotly",
   "pyaml",
   "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "numpy",
   "pandas",
   "plotly",
-  "pyaml",
+  "pyyaml",
   "requests",
   "urllib3>=2.6.0", # fix security issue
   "ipywidgets",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
   "matplotlib",
   "matpowercaseframes",
   "nbformat",
-  "numba",
   "numpy",
   "pandas",
   "plotly",


### PR DESCRIPTION
`pathlib` has been in the standard library since 3.4. The PyPI package of that name is an abandoned Python 2 backport that can shadow the stdlib module.

`numba` is declared but imported nowhere in the package, the scripts or the tests. It pulls in llvmlite and constrains the numpy range for nothing.

The code imports `yaml` and never imports `pyaml`, so the declared dependency should be `pyyaml`.
