### PR TITLE
Add a timeout and retries to the PGLib download

### DIFF
--- a/gridfm_datakit/network.py
+++ b/gridfm_datakit/network.py
@@ -683,6 +683,11 @@ _DOWNLOAD_RETRY = Retry(
 
 
 def _pglib_session() -> requests.Session:
+    """Build the HTTP session used to download PGLib case files.
+
+    Returns:
+        requests.Session: Session with the retry policy mounted for https.
+    """
     session = requests.Session()
     session.mount("https://", HTTPAdapter(max_retries=_DOWNLOAD_RETRY))
     return session

--- a/gridfm_datakit/network.py
+++ b/gridfm_datakit/network.py
@@ -17,6 +17,8 @@ import numpy as np
 import pandas as pd
 import requests
 from juliapkg.deps import executable
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 try:
     # juliapkg >= 0.1.24 renamed run_julia to run_script (signature unchanged).
@@ -669,6 +671,23 @@ def load_net_from_file(network_path: str) -> Network:
     return Network(mpc)
 
 
+# (connect, read) seconds: the handshake is fast, a large .m file streams slowly.
+# Retries cover raw.githubusercontent.com's transient 5xx and rate limiting.
+_DOWNLOAD_TIMEOUT = (5, 60)
+_DOWNLOAD_RETRY = Retry(
+    total=4,
+    backoff_factor=0.5,
+    status_forcelist=(429, 500, 502, 503, 504),
+    allowed_methods=frozenset({"GET"}),
+)
+
+
+def _pglib_session() -> requests.Session:
+    session = requests.Session()
+    session.mount("https://", HTTPAdapter(max_retries=_DOWNLOAD_RETRY))
+    return session
+
+
 def get_pglib_file_path(grid_name: str) -> str:
     """Return the local path to a PGLib network file, downloading it if necessary.
 
@@ -685,7 +704,8 @@ def get_pglib_file_path(grid_name: str) -> str:
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
     if not os.path.exists(file_path):
         url = f"https://raw.githubusercontent.com/power-grid-lib/pglib-opf/master/pglib_opf_{grid_name}.m"
-        response = requests.get(url)
+        with _pglib_session() as session:
+            response = session.get(url, timeout=_DOWNLOAD_TIMEOUT)
         response.raise_for_status()
         with open(file_path, "wb") as f:
             f.write(response.content)

--- a/tests/test_pglib_download.py
+++ b/tests/test_pglib_download.py
@@ -1,0 +1,51 @@
+"""Tests for the PGLib grid download in gridfm_datakit.network."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from gridfm_datakit import network
+
+
+class _Response:
+    content = b"function mpc = pglib_opf_case14_ieee\nmpc.baseMVA = 100;\n"
+
+    def raise_for_status(self):
+        return None
+
+
+def test_pglib_session_retries_transient_failures():
+    session = network._pglib_session()
+    retry = session.get_adapter("https://raw.githubusercontent.com").max_retries
+
+    assert retry.total == 4
+    assert set(retry.status_forcelist) >= {429, 500, 502, 503, 504}
+
+
+def test_pglib_download_passes_a_timeout(tmp_path, monkeypatch):
+    calls = {}
+
+    class _Session:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def get(self, url, timeout=None):
+            calls["url"] = url
+            calls["timeout"] = timeout
+            return _Response()
+
+    monkeypatch.setattr(network, "_pglib_session", _Session)
+    monkeypatch.setattr(network, "correct_network", lambda path: path)
+    monkeypatch.setattr(
+        network,
+        "resources",
+        SimpleNamespace(files=lambda pkg: tmp_path),
+    )
+
+    file_path = network.get_pglib_file_path("case14_ieee")
+
+    assert calls["timeout"] == (5, 60)
+    assert calls["url"].endswith("pglib_opf_case14_ieee.m")
+    assert Path(file_path).read_bytes() == _Response.content


### PR DESCRIPTION
`requests.get(url)` has no timeout, so a stalled connection blocks a generation worker indefinitely and a single transient 503 from raw.githubusercontent.com fails a whole run.

The download now goes through a session with connect and read timeouts and a urllib3 retry over 429 and 5xx with backoff. `urllib3` is already a dependency so nothing new is added.
