### PR TITLE
Bound CI runs and fix the pip cache key

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -8,9 +8,14 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pre-commit-run:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -35,6 +40,7 @@ jobs:
 
   security-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container: python:3.12-slim
     steps:
       - uses: actions/checkout@v4
@@ -57,6 +63,7 @@ jobs:
 
   pytests:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -118,6 +125,7 @@ jobs:
 
   dynamic-pytests:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     env:
       DYNAWO_VERSION: '1.7.0'
     steps:
@@ -193,6 +201,7 @@ jobs:
   codeql:
     name: CodeQL (Python)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v3

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}
+          key: pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             pip-${{ runner.os }}-
 
@@ -145,7 +145,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
-          key: pip-${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}
+          key: pip-${{ runner.os }}-${{ hashFiles('pyproject.toml') }}
           restore-keys: |
             pip-${{ runner.os }}-
 


### PR DESCRIPTION
The workflow has no concurrency group, so pushes to the same PR queue full pipeline runs in parallel, and no job timeout, so a hung job runs until the 6 hour default limit. This adds a concurrency group with cancel-in-progress and a timeout on every job.

The pip cache key in the pytests and dynamic-pytests jobs hashes `**/requirements*.txt`, which does not exist in this repository. The key evaluates to the constant `pip-Linux-`, so the cache never invalidates when dependencies change. It now hashes `pyproject.toml`.

The same key is broken in the two jobs that #76 removes wholesale, so those are left alone to keep the two changes independent.
