### PR TITLE
Fix validate failing after a second generation run

### DIFF
--- a/docs/manual/outputs.md
+++ b/docs/manual/outputs.md
@@ -18,7 +18,14 @@ Progress bar log showing the execution progress of the data generation process.
 Error messages captured during generation.
 
 #### `args.log`
-YAML dump of the configuration used for this run.
+YAML dump of the configuration used for this run. Appended to, so a directory reused
+across runs holds one timestamped block per run.
+
+### Configuration Files
+
+#### `config.yaml`
+YAML dump of the configuration used for this run, rewritten on every run. This is what
+`gridfm-datakit validate` reads to recover the operating mode when `--mode` is omitted.
 
 ### Load Scenario Files
 

--- a/gridfm_datakit/cli.py
+++ b/gridfm_datakit/cli.py
@@ -54,13 +54,24 @@ def _config_has_dynamic_block(config_path: str) -> bool:
     return isinstance(config, dict) and bool(config.get("dynamic"))
 
 
-# config.yaml is rewritten each run and is the primary source. args.log is appended
-# to, so a reused directory holds one timestamped YAML block per run and only the
-# last is current; it is read only for datasets generated before config.yaml existed.
 _RUN_HEADER = "\nNew generation started at "
 
 
 def _read_run_config(data_path: Path) -> tuple[str, dict | None]:
+    """Read the run configuration written alongside a generated dataset.
+
+    config.yaml is rewritten on every run and is the primary source. args.log is
+    appended to instead, so a directory reused across runs holds one timestamped
+    YAML block per run and only the last is current. It is read only for datasets
+    generated before config.yaml existed.
+
+    Args:
+        data_path (Path): Directory containing the generated files.
+
+    Returns:
+        tuple[str, dict | None]: The file the configuration came from, and the
+            parsed configuration, or None if neither file could be read.
+    """
     config_path = data_path / "config.yaml"
     if config_path.exists():
         try:
@@ -97,7 +108,8 @@ def validate_data_directory(
     Args:
         data_path (str): Path to directory containing generated files
         n_partitions (int): Number of partitions to sample for validation (0 = all partitions)
-        mode (str): Operating mode ("opf" or "pf"). If None, reads from args.log.
+        mode (str): Operating mode ("opf" or "pf"). If None, reads from config.yaml,
+            falling back to args.log.
 
     Returns:
         bool: True if all validations pass, False otherwise
@@ -261,7 +273,7 @@ Examples:
         type=str,
         default=None,
         choices=["opf", "pf"],
-        help="Operating mode: 'opf' or 'pf'. If not provided, reads from args.log in data directory.",
+        help="Operating mode: 'opf' or 'pf'. If not provided, reads from config.yaml in the data directory, falling back to args.log.",
     )
     validate_parser.add_argument(
         "--sn-mva",

--- a/gridfm_datakit/cli.py
+++ b/gridfm_datakit/cli.py
@@ -54,6 +54,37 @@ def _config_has_dynamic_block(config_path: str) -> bool:
     return isinstance(config, dict) and bool(config.get("dynamic"))
 
 
+# config.yaml is rewritten each run and is the primary source. args.log is appended
+# to, so a reused directory holds one timestamped YAML block per run and only the
+# last is current; it is read only for datasets generated before config.yaml existed.
+_RUN_HEADER = "\nNew generation started at "
+
+
+def _read_run_config(data_path: Path) -> tuple[str, dict | None]:
+    config_path = data_path / "config.yaml"
+    if config_path.exists():
+        try:
+            with open(config_path, "r") as f:
+                return "config.yaml", yaml.safe_load(f)
+        except Exception as e:
+            print(f"   Could not read config.yaml: {e}")
+
+    args_log = data_path / "args.log"
+    if args_log.exists():
+        try:
+            with open(args_log, "r") as f:
+                blocks = f.read().split(_RUN_HEADER)
+            for block in reversed(blocks):
+                _, _, body = block.partition("\n")
+                parsed = yaml.safe_load(body) if body.strip() else None
+                if isinstance(parsed, dict):
+                    return "args.log", parsed
+        except Exception as e:
+            print(f"   Could not read args.log: {e}")
+
+    return "config.yaml", None
+
+
 def validate_data_directory(
     data_path: str,
     sn_mva: float,
@@ -83,22 +114,21 @@ def validate_data_directory(
         "runtime_data": "runtime_data.parquet",
     }
 
-    # Determine mode: use provided mode or read from args.log
+    # Determine mode: use provided mode or read from the run configuration
     if mode is None:
-        try:
-            with open(data_path / "args.log", "r") as f:
-                lines = f.readlines()
-                # Skip the first two lines (empty line and timestamp)
-                yaml_content = "".join(lines[2:])
-                args = yaml.safe_load(yaml_content)
-            mode = args["settings"]["mode"]
-            print(f"   Found mode from args.log: {mode}")
-        except Exception as e:
-            print(f"   Could not read mode from args.log: {e}")
+        source, args = _read_run_config(data_path)
+        if args is None:
             print(
-                "   ERROR: Mode must be provided via --mode argument or args.log file",
+                "   ERROR: Mode must be provided via --mode argument, or "
+                "config.yaml or args.log must be readable",
             )
             return False
+        try:
+            mode = args["settings"]["mode"]
+        except (KeyError, TypeError):
+            print(f"   ERROR: No settings.mode in {source}")
+            return False
+        print(f"   Found mode from {source}: {mode}")
     else:
         print(f"   Using provided mode: {mode}")
 

--- a/gridfm_datakit/generate.py
+++ b/gridfm_datakit/generate.py
@@ -162,6 +162,7 @@ def _setup_environment(
         "tqdm_log": os.path.join(base_path, "tqdm.log"),
         "error_log": os.path.join(base_path, "error.log"),
         "args_log": os.path.join(base_path, "args.log"),
+        "config": os.path.join(base_path, "config.yaml"),
         "solver_log_dir": solver_log_dir,
         "bus_data": os.path.join(base_path, "bus_data.parquet"),
         "branch_data": os.path.join(base_path, "branch_data.parquet"),
@@ -194,6 +195,9 @@ def _setup_environment(
             f.write(f"\nNew generation started at {timestamp}\n")
             if log_file == file_paths["args_log"]:
                 yaml.safe_dump(args.to_dict(), f)
+
+    with open(file_paths["config"], "w") as f:
+        yaml.safe_dump(args.to_dict(), f)
 
     return args, base_path, file_paths, seed
 
@@ -313,6 +317,7 @@ def generate_power_flow_data(
             'tqdm_log': progress log file,
             'error_log': error log file,
             'args_log': configuration dump file,
+            'config': run configuration (YAML),
             'bus_data': bus-level features CSV (BUS_COLUMNS),
             'branch_data': branch-level features CSV (BRANCH_COLUMNS),
             'gen_data': generator features CSV (GEN_COLUMNS),
@@ -327,7 +332,8 @@ def generate_power_flow_data(
 
         - tqdm.log: Progress tracking
         - error.log: Error messages
-        - args.log: Configuration parameters (YAML dump)
+        - args.log: Configuration parameters (YAML dump, appended per run)
+        - config.yaml: Run configuration, rewritten each run
         - bus_data.parquet: Bus-level features for each scenario
         - branch_data.parquet: Branch-level features for each scenario
         - gen_data.parquet: Generator features for each scenario
@@ -459,7 +465,8 @@ def generate_power_flow_data_distributed(
 
         - tqdm.log: Progress tracking
         - error.log: Error messages
-        - args.log: Configuration parameters (YAML dump)
+        - args.log: Configuration parameters (YAML dump, appended per run)
+        - config.yaml: Run configuration, rewritten each run
         - bus_data.parquet: Bus-level features for each scenario
         - branch_data.parquet: Branch-level features for each scenario
         - gen_data.parquet: Generator features for each scenario

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,0 +1,50 @@
+"""Tests for run configuration recovery in gridfm_datakit.cli."""
+
+import yaml
+
+from gridfm_datakit.cli import _read_run_config
+
+CONFIG = {"settings": {"mode": "pf"}, "load": {"scenarios": 10}}
+
+
+def _append_run(path, mode):
+    config = {"settings": {"mode": mode}, "load": {"scenarios": 10}}
+    with open(path, "a") as f:
+        f.write("\nNew generation started at 2026-08-26 10:00:00\n")
+        yaml.safe_dump(config, f)
+
+
+def test_config_yaml_is_preferred(tmp_path):
+    with open(tmp_path / "config.yaml", "w") as f:
+        yaml.safe_dump(CONFIG, f)
+    _append_run(tmp_path / "args.log", "opf")
+
+    source, args = _read_run_config(tmp_path)
+
+    assert source == "config.yaml"
+    assert args["settings"]["mode"] == "pf"
+
+
+def test_args_log_fallback_for_a_single_run(tmp_path):
+    _append_run(tmp_path / "args.log", "opf")
+
+    source, args = _read_run_config(tmp_path)
+
+    assert source == "args.log"
+    assert args["settings"]["mode"] == "opf"
+
+
+def test_args_log_fallback_uses_the_last_run(tmp_path):
+    _append_run(tmp_path / "args.log", "pf")
+    _append_run(tmp_path / "args.log", "opf")
+
+    source, args = _read_run_config(tmp_path)
+
+    assert source == "args.log"
+    assert args["settings"]["mode"] == "opf"
+
+
+def test_missing_configuration_reports_nothing(tmp_path):
+    source, args = _read_run_config(tmp_path)
+
+    assert args is None


### PR DESCRIPTION
`args.log` is opened in append mode, so a directory reused across runs holds one timestamped YAML block per run. `validate` recovers the mode by skipping the first two lines and parsing the remainder, which stops being valid YAML as soon as a second run appends to it. Generating twice into the same directory makes `gridfm-datakit validate` fail.

Generation now also writes `config.yaml`, rewritten on each run, and `validate` reads that. Datasets generated before this fall back to `args.log`, taking the last block instead of the whole file.
