### PR TITLE
Cache downloaded grids outside the installed package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
 recursive-include gridfm_datakit/load_profiles *.csv
-recursive-include gridfm_datakit/grids *.m
 recursive-include gridfm_datakit/process *.m
 include gridfm_datakit/juliapkg.json

--- a/docs/components/network.md
+++ b/docs/components/network.md
@@ -13,3 +13,11 @@ This module provides functionality for loading, processing, and saving power sys
 ### `load_net_from_pglib`
 
 ::: gridfm_datakit.network.load_net_from_pglib
+
+### `get_pglib_source_path`
+
+::: gridfm_datakit.network.get_pglib_source_path
+
+### `grids_cache_dir`
+
+::: gridfm_datakit.network.grids_cache_dir

--- a/docs/manual/network.md
+++ b/docs/manual/network.md
@@ -21,6 +21,24 @@ network:
   name: "case24_ieee_rts"   # Name of the power grid network **without the pglib prefix**
 ```
 
+### Where downloaded cases are stored
+
+A PGLib case is downloaded the first time it is used and then cached on disk, so later
+runs need no network access. The cache holds both the file published by PGLib and the
+PowerModels-corrected copy used for solving.
+
+By default it lives in the platform user cache directory, which is
+`~/.cache/gridfm-datakit/grids` on Linux, `~/Library/Caches/gridfm-datakit/grids` on
+macOS and the local app data directory on Windows. Nothing is written inside the
+installed package, so `gridfm-datakit` works from a read-only installation.
+
+Set `GRIDFM_DATAKIT_CACHE_DIR` to move the cache elsewhere, which is useful for a shared
+cache on a cluster or a warm cache in CI.
+
+```bash
+export GRIDFM_DATAKIT_CACHE_DIR=/scratch/gridfm-cache
+```
+
 ## Local MATPOWER files
 
 e.g.

--- a/gridfm_datakit/network.py
+++ b/gridfm_datakit/network.py
@@ -7,14 +7,13 @@ networks in MATPOWER format, with support for non-continuous bus indexing.
 
 import io
 import os
-import shutil
 import tempfile
 import warnings
-from importlib import resources
 from typing import Any, Dict, Tuple
 
 import numpy as np
 import pandas as pd
+import platformdirs
 import requests
 from juliapkg.deps import executable
 from requests.adapters import HTTPAdapter
@@ -85,8 +84,12 @@ def correct_network(network_path: str, force: bool = False) -> str:
     if os.path.exists(corrected_path) and not force:
         return corrected_path
 
-    # Use temporary file for atomic replace
-    tmp_fd, tmp_path = tempfile.mkstemp(suffix=".m")
+    # Temp file in the destination directory so the replace below is atomic rather
+    # than a cross-device copy.
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        dir=os.path.dirname(corrected_path) or ".",
+        suffix=".m.part",
+    )
     os.close(tmp_fd)
 
     try:
@@ -109,8 +112,7 @@ def correct_network(network_path: str, force: bool = False) -> str:
         if not os.path.exists(tmp_path) or os.path.getsize(tmp_path) == 0:
             raise RuntimeError("Julia produced empty MATPOWER file")
 
-        # Atomically replace target file (use shutil.move to allow cross-device)
-        shutil.move(tmp_path, corrected_path)
+        os.replace(tmp_path, corrected_path)
         return corrected_path
 
     finally:
@@ -693,6 +695,59 @@ def _pglib_session() -> requests.Session:
     return session
 
 
+# Downloaded grids are a user cache, not package data: site-packages may be read
+# only, survives no uninstall, and is shared by every process using the install.
+# Override with GRIDFM_DATAKIT_CACHE_DIR. Downloads land on a temporary file in the
+# cache directory and are os.replace'd into place, so concurrent workers either see
+# no file or a complete one, never a partial download.
+CACHE_DIR_ENV_VAR = "GRIDFM_DATAKIT_CACHE_DIR"
+
+
+def grids_cache_dir() -> str:
+    """Return the directory holding downloaded PGLib files, creating it if needed.
+
+    Returns:
+        Absolute path to the grid cache directory.
+    """
+    root = os.environ.get(CACHE_DIR_ENV_VAR) or platformdirs.user_cache_dir(
+        "gridfm-datakit",
+    )
+    path = os.path.join(root, "grids")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def get_pglib_source_path(grid_name: str) -> str:
+    """Return the local path to an original PGLib file, downloading it if necessary.
+
+    Args:
+        grid_name: Name of the grid file without the prefix 'pglib_opf_'
+                  (e.g., 'case14_ieee', 'case118_ieee').
+
+    Returns:
+        Absolute path to the local .m file as published by PGLib.
+    """
+    cache_dir = grids_cache_dir()
+    file_path = os.path.join(cache_dir, f"pglib_opf_{grid_name}.m")
+    if os.path.exists(file_path):
+        return file_path
+
+    url = f"https://raw.githubusercontent.com/power-grid-lib/pglib-opf/master/pglib_opf_{grid_name}.m"
+    with _pglib_session() as session:
+        response = session.get(url, timeout=_DOWNLOAD_TIMEOUT)
+    response.raise_for_status()
+
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=cache_dir, suffix=".m.part")
+    try:
+        with os.fdopen(tmp_fd, "wb") as f:
+            f.write(response.content)
+        os.replace(tmp_path, file_path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+    return file_path
+
+
 def get_pglib_file_path(grid_name: str) -> str:
     """Return the local path to a PGLib network file, downloading it if necessary.
 
@@ -703,18 +758,7 @@ def get_pglib_file_path(grid_name: str) -> str:
     Returns:
         Absolute path to the (corrected) local .m file.
     """
-    file_path = str(
-        resources.files("gridfm_datakit.grids").joinpath(f"pglib_opf_{grid_name}.m"),
-    )
-    os.makedirs(os.path.dirname(file_path), exist_ok=True)
-    if not os.path.exists(file_path):
-        url = f"https://raw.githubusercontent.com/power-grid-lib/pglib-opf/master/pglib_opf_{grid_name}.m"
-        with _pglib_session() as session:
-            response = session.get(url, timeout=_DOWNLOAD_TIMEOUT)
-        response.raise_for_status()
-        with open(file_path, "wb") as f:
-            f.write(response.content)
-    return correct_network(file_path)
+    return correct_network(get_pglib_source_path(grid_name))
 
 
 def load_net_from_pglib(grid_name: str) -> Network:

--- a/gridfm_datakit/process/solvers.py
+++ b/gridfm_datakit/process/solvers.py
@@ -12,7 +12,7 @@ import numpy as np
 import tempfile
 import os
 from typing import Any, Dict
-from gridfm_datakit.network import Network
+from gridfm_datakit.network import Network, get_pglib_source_path
 from gridfm_datakit.process.solver_output import solver_capture
 from gridfm_datakit.utils.idx_brch import (
     ANGMAX,
@@ -314,8 +314,6 @@ def compare_pf_results(
         FileNotFoundError: If the original case file is not found.
         ValueError: If solver_type is not "pf" or "opf".
     """
-    import os
-
     if solver_type not in ["pf", "opf"]:
         raise ValueError(f"solver_type must be 'pf' or 'opf', got '{solver_type}'")
 
@@ -334,10 +332,7 @@ def compare_pf_results(
         temp_converged = False
 
     # Step 2: Run solver directly on original case file
-    original_file_path = f"gridfm_datakit/grids/pglib_opf_{case_name}.m"
-
-    if not os.path.exists(original_file_path):
-        raise FileNotFoundError(f"Original case file not found: {original_file_path}")
+    original_file_path = get_pglib_source_path(case_name)
 
     print(f"Running {solver_name} directly on original file: {original_file_path}")
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
   "juliacall>=0.9.34",
   "tqdm",
   "pyarrow",
+  "platformdirs",
 ]
 
 authors = [

--- a/tests/powsybl/test_load_net.py
+++ b/tests/powsybl/test_load_net.py
@@ -15,10 +15,10 @@ What is tested
 * Appropriate exceptions are raised for bad input.
 """
 
-from pathlib import Path
-
 import numpy as np
 import pytest
+
+from gridfm_datakit.network import get_pglib_source_path
 
 import gridfm_datakit.powsybl as powsybl
 from gridfm_datakit.network import Network
@@ -54,12 +54,11 @@ def xiidm_case14_path(tmp_path_factory):
 @pytest.fixture(scope="module")
 def matpower_case14_path():
     """
-    Return the path to the bundled MATPOWER pglib case14 .m file.
+    Return the path to the PGLib MATPOWER case14 .m file.
 
-    This file lives in gridfm_datakit's own ``grids/`` package directory.
+    Downloaded on demand into the gridfm_datakit grid cache.
     """
-    grids_dir = Path(__file__).parent.parent.parent / "gridfm_datakit" / "grids"
-    return str(grids_dir / "pglib_opf_case14_ieee.m")
+    return get_pglib_source_path("case14_ieee")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/powsybl/test_workflow.py
+++ b/tests/powsybl/test_workflow.py
@@ -38,10 +38,10 @@ them from metadata and persist them externally before handing the pp_net off
 to a pypowsybl solver or exporter.
 """
 
-from pathlib import Path
-
 import numpy as np
 import pytest
+
+from gridfm_datakit.network import get_pglib_source_path
 
 import gridfm_datakit.powsybl as powsybl
 from gridfm_datakit.utils.idx_cost import COST, MODEL, NCOST, POLYNOMIAL
@@ -74,13 +74,12 @@ def xiidm_case14_path(tmp_path_factory):
 @pytest.fixture(scope="module")
 def matpower_case14_path():
     """
-    Return the path to the bundled PGLib MATPOWER case14 .m file.
+    Return the path to the PGLib MATPOWER case14 .m file.
 
-    This file is shipped with gridfm_datakit and contains a full MATPOWER
-    case including a gencost block with real quadratic cost coefficients.
+    Downloaded on demand into the gridfm_datakit grid cache. Contains a full
+    MATPOWER case including a gencost block with real quadratic cost coefficients.
     """
-    grids_dir = Path(__file__).parent.parent.parent / "gridfm_datakit" / "grids"
-    return str(grids_dir / "pglib_opf_case14_ieee.m")
+    return get_pglib_source_path("case14_ieee")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pglib_download.py
+++ b/tests/test_pglib_download.py
@@ -1,7 +1,7 @@
-"""Tests for the PGLib grid download in gridfm_datakit.network."""
+"""Tests for the PGLib grid cache and download in gridfm_datakit.network."""
 
+import os
 from pathlib import Path
-from types import SimpleNamespace
 
 from gridfm_datakit import network
 
@@ -13,6 +13,26 @@ class _Response:
         return None
 
 
+class _Session:
+    calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+    def get(self, url, timeout=None):
+        type(self).calls.append({"url": url, "timeout": timeout})
+        return _Response()
+
+
+def _use_cache(tmp_path, monkeypatch):
+    monkeypatch.setenv(network.CACHE_DIR_ENV_VAR, str(tmp_path))
+    _Session.calls = []
+    monkeypatch.setattr(network, "_pglib_session", _Session)
+
+
 def test_pglib_session_retries_transient_failures():
     session = network._pglib_session()
     retry = session.get_adapter("https://raw.githubusercontent.com").max_retries
@@ -21,31 +41,39 @@ def test_pglib_session_retries_transient_failures():
     assert set(retry.status_forcelist) >= {429, 500, 502, 503, 504}
 
 
-def test_pglib_download_passes_a_timeout(tmp_path, monkeypatch):
-    calls = {}
+def test_cache_dir_honours_the_environment_override(tmp_path, monkeypatch):
+    monkeypatch.setenv(network.CACHE_DIR_ENV_VAR, str(tmp_path))
 
-    class _Session:
-        def __enter__(self):
-            return self
+    cache_dir = Path(network.grids_cache_dir())
 
-        def __exit__(self, *exc_info):
-            return False
+    assert cache_dir == tmp_path / "grids"
+    assert cache_dir.is_dir()
 
-        def get(self, url, timeout=None):
-            calls["url"] = url
-            calls["timeout"] = timeout
-            return _Response()
 
-    monkeypatch.setattr(network, "_pglib_session", _Session)
-    monkeypatch.setattr(network, "correct_network", lambda path: path)
-    monkeypatch.setattr(
-        network,
-        "resources",
-        SimpleNamespace(files=lambda pkg: tmp_path),
-    )
+def test_download_writes_into_the_cache_not_the_package(tmp_path, monkeypatch):
+    _use_cache(tmp_path, monkeypatch)
 
-    file_path = network.get_pglib_file_path("case14_ieee")
+    file_path = Path(network.get_pglib_source_path("case14_ieee"))
 
-    assert calls["timeout"] == (5, 60)
-    assert calls["url"].endswith("pglib_opf_case14_ieee.m")
-    assert Path(file_path).read_bytes() == _Response.content
+    assert file_path == tmp_path / "grids" / "pglib_opf_case14_ieee.m"
+    assert file_path.read_bytes() == _Response.content
+    assert _Session.calls[0]["timeout"] == (5, 60)
+    assert _Session.calls[0]["url"].endswith("pglib_opf_case14_ieee.m")
+
+
+def test_download_leaves_no_partial_file(tmp_path, monkeypatch):
+    _use_cache(tmp_path, monkeypatch)
+
+    network.get_pglib_source_path("case14_ieee")
+
+    leftovers = [n for n in os.listdir(tmp_path / "grids") if n.endswith(".part")]
+    assert leftovers == []
+
+
+def test_cached_file_is_not_downloaded_again(tmp_path, monkeypatch):
+    _use_cache(tmp_path, monkeypatch)
+
+    network.get_pglib_source_path("case14_ieee")
+    network.get_pglib_source_path("case14_ieee")
+
+    assert len(_Session.calls) == 1

--- a/tests/test_verify_network.py
+++ b/tests/test_verify_network.py
@@ -14,6 +14,7 @@ from gridfm_datakit.network import (
 )
 from gridfm_datakit.utils.idx_bus import BUS_TYPE, PV, PQ
 from gridfm_datakit.process.process_network import init_julia
+from gridfm_datakit.network import get_pglib_source_path
 import numpy as np
 
 
@@ -76,7 +77,7 @@ def verify_branch_direction():
     net = load_net_from_pglib(case_name)
 
     # Parse with PowerModels
-    parse = jl.PowerModels.parse_file(f"gridfm_datakit/grids/pglib_opf_{case_name}.m")
+    parse = jl.PowerModels.parse_file(get_pglib_source_path(case_name))
 
     active_branches = net.idx_branches_in_service
     for branch_idx in active_branches:
@@ -148,7 +149,7 @@ def verify_generator_bus_assignment():
     net = load_net_from_pglib(case_name)
 
     # Parse with PowerModels
-    parse = jl.PowerModels.parse_file(f"gridfm_datakit/grids/pglib_opf_{case_name}.m")
+    parse = jl.PowerModels.parse_file(get_pglib_source_path(case_name))
 
     # Check each generator's bus assignment
     for gen_idx in range(net.gens.shape[0]):


### PR DESCRIPTION
Depends on #79 and is branched off it. Both rewrite `get_pglib_file_path`, so #79 should merge first. Until it does, the diff here also contains #79's commits.

Downloaded grids and their corrected copies are written into `resources.files("gridfm_datakit.grids")`, which is site-packages. That fails on read-only installs, leaves files behind after uninstall, and lets parallel workers read a partial download from a shared location. They now go to `platformdirs.user_cache_dir("gridfm-datakit")/grids`, overridable with `GRIDFM_DATAKIT_CACHE_DIR`. Downloads land on a temp file in that directory and are `os.replace`d into place. `correct_network` now creates its temp file in the destination directory as well, so its replace is atomic instead of a possibly cross-device move.

Two things turned up while doing this.

`solvers.py` and `test_verify_network.py` resolved `gridfm_datakit/grids/pglib_opf_{case}.m` against the working directory, so they only worked when run from the repo root. They now go through the resolver. `get_pglib_source_path` returns the original file and `get_pglib_file_path` the corrected one, since those call sites need the original.

`MANIFEST.in` had `recursive-include gridfm_datakit/grids *.m`. Every `.m` file there is gitignored and downloaded at runtime, so building an sdist from a tree where tests had run would ship a download cache as package data. That line is removed.

This adds `platformdirs` as a runtime dependency, which cuts against #78. It is pure Python with no transitive dependencies and is what the review recommends, but say the word if you would rather have a stdlib XDG fallback instead.
