### PR TITLE
Release 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "gridfm-datakit"
 description = "Data Generation Kit"
 readme = "README.md"
 license = "Apache-2.0"
-version = "1.1.0rc1"
+version = "1.1.0"
 requires-python = ">=3.10,<3.13"
 
 dependencies = [


### PR DESCRIPTION
Promotes `1.1.0rc1` → `1.1.0` (final). One-line version bump in `pyproject.toml`.

**Why this is safe as-is:** `main` is byte-identical to the `v1.1.0rc1` tag (0 commits ahead), which has been on PyPI as a pre-release since 2026-08-24, is depended on by gridfm-graphkit, and was validated on Vela (all PF+OPF integration metrics within baseline bounds). No code changes here.

After merge: a non-prerelease GitHub release for tag `v1.1.0` will trigger `release.yaml` → PyPI publish, then graphkit will be re-pointed to `==1.1.0`.

<!-- gridfm-agent -->